### PR TITLE
set the user agent to mimic a headful version of puppeteer running

### DIFF
--- a/libs/core-scanner/src/core-scanner.service.ts
+++ b/libs/core-scanner/src/core-scanner.service.ts
@@ -18,6 +18,9 @@ import { ScanStatus } from './scan-status';
 import { v4 } from 'uuid';
 import { Agent } from 'https';
 
+// We set the user agent to what it would be if we were not running headless chrome
+const USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.75 Safari/537.36"
+
 @Injectable()
 export class CoreScannerService
   implements Scanner<CoreInputDto, CoreResult>, OnModuleDestroy {
@@ -42,6 +45,7 @@ export class CoreScannerService
 
       // load the url
       this.logger.debug(`loading ${url}`);
+      page.setUserAgent(USER_AGENT)
       const response = await page.goto(url, {
         waitUntil: 'networkidle2',
       });


### PR DESCRIPTION
This sets the user-agent of the puppeteer instance so that instead of showing up like

```
Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/79.0.3945.0 Safari/537.36
```

it will not have the HeadlessChrome specified but a headful chrome. There is an issue with some sites where we are getting 403s (approximately 6% of sites return 403) and after spot checking with some sites this appears to prompt a valid response.

Masking the user-agent does attempt to hide the fact this is running from Headless, which is the main way sites do auto-detection for bots that are running on a more light-weight chrome. A question is if this shielding breaks the "contract" a requester has with the site, by changing the appearance to something it is not. I believe that this fix is worth the data we will receive, but am open to other opinions. 