### PR TITLE
Enforce SSL when interacting with PostgreSQL

### DIFF
--- a/libs/database/src/database.module.ts
+++ b/libs/database/src/database.module.ts
@@ -21,6 +21,7 @@ const ScannerDatabase = TypeOrmModule.forRootAsync({
       url: configService.get<string>('database.url'),
       entities: [Website, CoreResult, SolutionsResult],
       synchronize: true,
+      ssl: true,
     };
   },
   inject: [ConfigService],


### PR DESCRIPTION
Per https://github.com/GSA/site-scanning/issues/110, we need to configure SSL/TLS for PostgreSQL and Redis.  Redis already uses TLS in non-dev environments (see https://github.com/GSA/site-scanning-engine/blob/main/libs/message-queue/src/message-queue.module.ts#L22 ) so this ought to be the one and only change to resolve that issue.

The source for the SSL requirement change came from Stack Overflow:
https://stackoverflow.com/questions/56660312/cannot-connect-an-ssl-secured-database-to-typeorm/63043606#63043606