### PR TITLE
134 document dev environment

### DIFF
--- a/docs/environment_provisioning.md
+++ b/docs/environment_provisioning.md
@@ -1,0 +1,133 @@
+# Environment Provisioning
+
+## Overview
+
+Deploying to an environment (space) requires that the space exist --
+be provisionied -- before code can be deployed to it.  The steps to
+provision an environment include:
+
+1. Create the space on Cloud Foundry
+1. Create vars file for the environment
+1. Target the space on Cloud Foundry
+1. Create an API key for use with the environment
+1. Run the deployment script
+1. Test the new environment
+1. Verify that the service accounts can deploy to the environment
+
+## Detailed Instructions
+
+### 1. Create the space on Cloud Foundry
+
+First, verify that the environment you wish to create doesn't yet
+exist by using the `cf spaces command`  (note: you must be logged
+in first).
+
+Assuming the space does not yet exist, use the `cf create-space`
+command to create the space:
+
+```sh
+cf create-space NAME_OF_SPACE -o NAME_OF_ORG
+```
+
+Note: `NAME_OF_ORG` is the name of the organization in Cloud
+Foundry and `NAME_OF_SPACE` is the name of the space (environment)
+to be used.
+
+### 2. Create vars file for the environment
+
+Cloud Foundry uses `manifest.yml` files to describe the applications
+to be deployed to a space.  The `manifest.yml` file for this project
+uses [variable substitution](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#variable-substitution)
+to specify environment-specific variables (e.g., memory quota,
+number of instances, etc.).  The values for these variables are found
+in the `env-NAME_OF_SPACE.yml` files.  So, for example, the vars
+file for the `dev` environment is `vars-dev.yml` (case-sensitive).
+
+So, to create a vars file for a new environment, copy an existing
+vars file and supply the appropriate values.  Be sure to add the
+file to the repository (`git add`), commit it (`git commit`) and
+push it (`git push origin NAME_OF_BRANCH`) so that the deployment
+script is able to deploy changes to said environment.
+
+### 3. Target the space on Cloud Foundry
+
+The deployment script -- used to provision the environment -- uses
+the name of the space in order to select which vars file will be
+used with the environment.  Therefore, it's important to target
+the space by using the `cf target` command:
+
+```sh
+cf target -o NAME_OF_ORG -s NAME_OF_SPACE
+```
+
+### 4. Create an API key for use with the environment
+
+The deployment script requests the `API_KEY` to use with
+the deployed environment.  This `API_KEY` is passed along with
+API calls to authenticate the request.
+
+The API key is stored as a user-provided service, so its value
+is accessible via `cf env`.  Moreover, the only time that the key
+is needed is when connecting the API to an external service (e.g.,
+API Umbrella) or when querying the API directly (e.g., via `curl`).
+
+As a result, the value generally doesn't matter, particularly as
+an authorized agent may query Cloud Foundry to retrieve the value.
+
+That is, it could literally be a face-plant on the keyboard.
+
+### 5. Run the deployment script
+
+There is a deployment script that is used to provision the environment
+(space) called `cloudgov-deploy.sh`.  This script will not only
+push code to Cloud Foundry, but it will also wire up the required
+services (e.g., RDS Postgres, Redis, the API key, etc.).
+
+When the script is run, if there is no value for the `API_KEY`
+user-provided service, it will prompt the operator for a value.
+Provide the value previously discussed (or slap the keyboard a few
+times).
+
+Note: the process of creating and binding all of the services to the
+(new) applications takes a while -- don't be surprised if it takes
+upwards of 15..20 minutes to complete.  This is normal.
+
+### 6. Verify that the service accounts can deploy to the environment
+
+Once the application is provisioned, you, dear operator, should
+probably add the service accounts used to deploy other environments
+to this application.  One way to accomplish this is by listing the
+users who have access to other, existing spaces:
+
+```sh
+cf space-users NAME_OF_ORG NAME_OF_SPACE
+```
+
+To add a user to the new space:
+
+```sh
+cf set-space-role NAME_OF_USER NAME_OF_ORG NAME_OF_SPACE NAME_OF_ROLE
+```
+
+Here, `NAME_OF_USER` is the user's name and `NAME_OF_ROLE` is the
+name of the role to apply (e.g., `SpaceDeveloper`)
+
+Note: usernames for service accounts are typically strings of 36
+characters consisting of numbers, letters, and dashes.
+
+### 7. Test the new environment
+
+A running deployment may be tested from the command line with the
+`curl` command provided the API key (described previously) is
+passed in the `X-Secret-Api-Access-Token` HTTP header.
+
+In the following example, the following variables are used:
+
+* **key**: the API key (available from `cf env`)
+* **route**: the route (hostname, available from `cf app`)
+* **endpoint**: the endpoint to query (e.g., `/websites/`)
+
+```sh
+curl -H "X-Secret-Api-Access-Token: $key" "https://${route}${endpoint}"
+```
+

--- a/site_scanner_endpoint_test.bash
+++ b/site_scanner_endpoint_test.bash
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+## @file site_scanner_endpoint_test.bash
+## @brief perform a quick test of the Site Scanner API
+## @details
+## The Site Scanner exposes a RESTful API that may be queried via
+## HTTP requests using tools such as `curl`.  This tool will wrap
+## a `curl` request with the required headers and such in order to
+## test the API.  In most situations, the tool will be able to
+## fetch the required variables (API key, route, etc.) from
+## Cloud Foundry automatically.
+## @author Wes Dean <wesley.dean@gsa.gov>
+
+# if anything breaks, abort
+set -e
+
+## @fn show_help()
+## @brief display a help message then exit the program
+## @details
+## The first sed script takes line starting with the first Doxygen-
+## style 'file' parameter up to and including the first line with
+## the 'author' parameter; this becomes the first part of the help
+## message.
+##
+## So, to use this, the first part of the Bash script needs to
+## be Doxygen-style markup starting with the 'file' parameter
+## and should end with the 'author' parameter's line (that is,
+## we use the entire line that the 'author' parameter uses).
+##
+## Next, we use another sed script that looks for options to
+## getopts that have comments starting with ##- and extracts
+## the option followed by the comment.
+## @retval 0 (True) if sed was happy
+## @retval 1 (False) if sed was NOT happy
+## @par Example
+## @code
+## show_help ; exit 0
+## @endcode
+show_help() {
+  sed --zero-terminated \
+    --regexp-extended \
+    --expression='s/.*@[Ff]ile *(.*)@[Aa]uthor *([^\n]*).*/Usage: \1Author: \2\n\n/' \
+    --regexp-extended \
+    --expression='s/\B@[a-z]* *//g' \
+    --expression 's/## *//g' \
+    "$0"
+
+  echo "Usage:"
+
+ sed \
+   --quiet \
+   --regexp-extended \
+   --expression='s/^ *([A-Z]) * \).*#{2}- */    -\1 : /ip' \
+   "$0" \
+   | sort --ignore-case
+
+  echo
+  echo "Defaults:"
+  echo "    app = '$DEFAULT_APP'"
+  echo "    endpoint = '$DEFAULT_ENDPOINT'"
+  echo "    key = (retrieved from Cloud Foundry)"
+  echo "    org = (retrieved from Cloud Foundry)"
+  echo "    protocol = '$DEFAULT_PROTOCOL'"
+  echo "    route = (retried from Cloud Foundry)"
+  echo "    space = (retried from Cloud Foundry)"
+  echo
+}
+
+## @var DEFAULT_APP default Cloud Foundry app to query
+DEFAULT_APP="site-scanner-api"
+
+## @var DEFAULT_ENDPOINT default API endpoint to query
+DEFAULT_ENDPOINT="/websites/"
+
+## @var DEFAULT_KEY default key to use (retrieved)
+DEFAULT_KEY=""
+
+## @var DEFAULT_ORG default CF org to use (retrieved)
+DEFAULT_ORG=""
+
+## @var DEFAULT_PROTOCOL default protocol to use
+DEFAULT_PROTOCOL="https://"
+
+## @var DEFAULT_ROUTE default route to use (retrieved)
+DEFAULT_ROUTE=""
+
+## @var DEFAULT_SPACE default CF space to use (retrieved)
+DEFAULT_SPACE=""
+
+
+app="$DEFAULT_APP"
+endpoint="$DEFAULT_ENDPOINT"
+key="$DEFAULT_KEY"
+org="$DEFAULT_ORG"
+protocol="$DEFAULT_PROTOCOL"
+route="$DEFAULT_ROUTE"
+space="$DEFAULT_SPACE"
+
+
+while getopts "a:e:hk:o:p:r:s:" option ; do
+  case "$option" in
+    a ) app="$OPTARG" ;; ##- specify the app to query
+    e ) endpoint="$OPTARG" ;; ##- specify the API endpoint to query
+    h ) show_help ; exit 0 ;; ##- show help text
+    k ) key="$OPTARG" ;; ##- specify the key to use with the API
+    o ) org="$OPTARG" ;; ##- specify the Cloud Foundry organization
+    p ) protocol="$OPTARG" ;; ##- the protocol to use to query the API
+    r ) route="$OPTARG" ;; ##- specify the route to query
+    s ) space="$OPTARG" ;; ##- specify the Cloud Foundry space
+    * ) echo "Invalid option '$option'" 1>&2 ; show_help 1>&2 ; exit 1 ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+
+org="${org:-$(cf target | sed -nE -e 's/^[[:space:]]*org[[:space:]]*:[[:space:]]*(.*)/\1/p')}"
+space="${space:-$(cf target | sed -nE -e 's/^[[:space:]]*space[[:space:]]*:[[:space:]]*(.*)/\1/p')}"
+
+echo "org: '$org'" 1>&2
+echo "space: '$space'" 1>&2
+echo "app: '$app'" 1>&2
+
+key="${key:-$(cf env "$app" | sed -nE -e "s/^[[:space:]]*(['\"])*API_KEY\\1*[[:space:]]*:[[:space:]]*(['\"])*([^'\"]*)\\2*[[:space:]]*$/\\3/p")}"
+
+scheme="${scheme:-https://}"
+route="${route:-$(cf app "$app" | sed -nE -e 's/^routes[[:space:]]*:[[:space:]]*(.*)$/\1/p')}"
+url="${protocol}${url:-$(echo "${route}${endpoint}"| sed -Ee 's|//+|/|g')}"
+
+echo "Fetching '$url'" 1>&2
+curl -sH "X-Secret-Api-Access-Token: $key" "$url"


### PR DESCRIPTION
This is for [134](https://github.com/GSA/site-scanning/issues/134) (document dev environment); it includes documentation in markdown plus a script used to create test requests to the API directly using `curl`.  The script fetches stuff like the route, the API key, etc. automatically so one need only run `./site_scanner_endpoint_test.bash`.  