### PR TITLE
Restart worker Github Action workflow

### DIFF
--- a/.github/workflows/restart-worker.yml
+++ b/.github/workflows/restart-worker.yml
@@ -14,7 +14,7 @@ on:
         default: prod
 
 jobs:
-  enqueue:
+  restart:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/restart-worker.yml
+++ b/.github/workflows/restart-worker.yml
@@ -1,10 +1,10 @@
 ---
-name: Enqueue scans
+name: Restart scan worker/consumer
 
 # yamllint disable-line rule:truthy
 on:
   schedule:
-    - cron: '10 0 * * *'
+    - cron: '0 0 * * *'
 
   workflow_dispatch:
     inputs:
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: run enqueue-scans cli job in chosen space
+      - name: restart scan worker
         uses: danielnaab/cg-cli-tools@no-exec
         with:
           cf_api: https://api.fr.cloud.gov
@@ -26,7 +26,4 @@ jobs:
           cf_password: ${{ secrets.CF_PASSWORD }}
           cf_org: gsatts-sitescan
           cf_space: ${{ github.event.inputs.cf_space || 'prod' }}
-          cf_command: run-task site-scanner-consumer
-            -c "node dist/apps/cli/main.js enqueue-scans"
-            -k 2G -m 4G
-            --name github-action-enqueue-scans-${{ github.run_id }}
+          cf_command: restart site-scanner-consumer


### PR DESCRIPTION
Create Github Action workflow to restart scan consumers 10 minutes before daily enqueue job.

This moves the "enqueue-scans" job forward 10 minutes, and runs the restart job daily at 00:00 UTC.