### PR TITLE
Fix issue with site data not saving to the database

### DIFF
--- a/entities/scan-status.ts
+++ b/entities/scan-status.ts
@@ -13,25 +13,27 @@ export const parseBrowserError = (err: Error): ScanStatus => {
     return ScanStatus.Timeout;
   }
 
-  if (err.message.startsWith('net::ERR_NAME_NOT_RESOLVED')) {
-    return ScanStatus.DNSResolutionError;
-  }
+  if (err.message) {
+    if (err.message.startsWith('net::ERR_NAME_NOT_RESOLVED')) {
+      return ScanStatus.DNSResolutionError;
+    }
 
-  if (
-    err.message.startsWith('net::ERR_CERT_COMMON_NAME_INVALID') ||
-    err.message.startsWith('net::ERR_CERT_DATE_INVALID') ||
-    err.message.startsWith('net::ERR_BAD_SSL_CLIENT_AUTH_CERT') ||
-    err.message.startsWith('unable to verify the first certificate')
-  ) {
-    return ScanStatus.InvalidSSLCert;
-  }
+    if (
+      err.message.startsWith('net::ERR_CERT_COMMON_NAME_INVALID') ||
+      err.message.startsWith('net::ERR_CERT_DATE_INVALID') ||
+      err.message.startsWith('net::ERR_BAD_SSL_CLIENT_AUTH_CERT') ||
+      err.message.startsWith('unable to verify the first certificate')
+    ) {
+      return ScanStatus.InvalidSSLCert;
+    }
 
-  if (err.message.startsWith('net::ERR_CONNECTION_REFUSED')) {
-    return ScanStatus.ConnectionRefused;
-  }
+    if (err.message.startsWith('net::ERR_CONNECTION_REFUSED')) {
+      return ScanStatus.ConnectionRefused;
+    }
 
-  if (err.message.startsWith('net::ERR_CONNECTION_RESET')) {
-    return ScanStatus.ConnectionReset;
+    if (err.message.startsWith('net::ERR_CONNECTION_RESET')) {
+      return ScanStatus.ConnectionReset;
+    }
   }
 
   return ScanStatus.UnknownError;

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,3 @@
+# Notebooks
+
+This directory includes Jupyter Notebooks. Any adhoc exploration of scan data may be logged here for reference.

--- a/notebooks/scan-date-analysis.ipynb
+++ b/notebooks/scan-date-analysis.ipynb
@@ -1,0 +1,248 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Scan date analysis\n",
+    "\n",
+    "## Context\n",
+    "\n",
+    "See Github issue: [https://github.com/GSA/site-scanning/issues/201](https://github.com/GSA/site-scanning/issues/201)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "%pip install --quiet pandas jinja2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "from datetime import timedelta\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load data\n",
+    "\n",
+    "Read the most recent weekly snapshot and the target URL list into Pandas dataframes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "snapshot_df = pd.read_json(\"https://api.gsa.gov/technology/site-scanning/data/weekly-snapshot.json\")\n",
+    "snapshot_df['scan_date'] = pd.to_datetime(snapshot_df['scan_date'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_url_df = pd.read_csv('https://raw.githubusercontent.com/GSA/federal-website-index/main/data/site-scanning-target-url-list.csv')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get \"old\" scans"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "</style>\n",
+       "<table id=\"T_f7312\">\n",
+       "  <caption>Ten oldest scans before 2022-05-06 04:02:13.487000+00:00</caption>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_f7312_level0_col0\" class=\"col_heading level0 col0\" >scan_date</th>\n",
+       "      <th id=\"T_f7312_level0_col1\" class=\"col_heading level0 col1\" >target_url</th>\n",
+       "      <th id=\"T_f7312_level0_col2\" class=\"col_heading level0 col2\" >final_url</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_f7312_level0_row0\" class=\"row_heading level0 row0\" >14539</th>\n",
+       "      <td id=\"T_f7312_row0_col0\" class=\"data row0 col0\" >2022-03-03 07:48:38.419000+00:00</td>\n",
+       "      <td id=\"T_f7312_row0_col1\" class=\"data row0 col1\" >maps1.qa.coast.noaa.gov</td>\n",
+       "      <td id=\"T_f7312_row0_col2\" class=\"data row0 col2\" >https://maps1.qa.coast.noaa.gov/</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_f7312_level0_row1\" class=\"row_heading level0 row1\" >4198</th>\n",
+       "      <td id=\"T_f7312_row1_col0\" class=\"data row1 col0\" >2022-03-05 00:40:01.828000+00:00</td>\n",
+       "      <td id=\"T_f7312_row1_col1\" class=\"data row1 col1\" >imagery.qa.coast.noaa.gov</td>\n",
+       "      <td id=\"T_f7312_row1_col2\" class=\"data row1 col2\" >https://imagery.qa.coast.noaa.gov/</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_f7312_level0_row2\" class=\"row_heading level0 row2\" >11735</th>\n",
+       "      <td id=\"T_f7312_row2_col0\" class=\"data row2 col0\" >2022-03-15 00:44:20.802000+00:00</td>\n",
+       "      <td id=\"T_f7312_row2_col1\" class=\"data row2 col1\" >maps1.coast.noaa.gov</td>\n",
+       "      <td id=\"T_f7312_row2_col2\" class=\"data row2 col2\" >https://maps1.coast.noaa.gov/</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_f7312_level0_row3\" class=\"row_heading level0 row3\" >14376</th>\n",
+       "      <td id=\"T_f7312_row3_col0\" class=\"data row3 col0\" >2022-03-21 00:46:03.263000+00:00</td>\n",
+       "      <td id=\"T_f7312_row3_col1\" class=\"data row3 col1\" >maps.coast.noaa.gov</td>\n",
+       "      <td id=\"T_f7312_row3_col2\" class=\"data row3 col2\" >https://maps.coast.noaa.gov/</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_f7312_level0_row4\" class=\"row_heading level0 row4\" >5037</th>\n",
+       "      <td id=\"T_f7312_row4_col0\" class=\"data row4 col0\" >2022-03-25 00:43:34.087000+00:00</td>\n",
+       "      <td id=\"T_f7312_row4_col1\" class=\"data row4 col1\" >maps2.qa.coast.noaa.gov</td>\n",
+       "      <td id=\"T_f7312_row4_col2\" class=\"data row4 col2\" >https://maps2.qa.coast.noaa.gov/</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_f7312_level0_row5\" class=\"row_heading level0 row5\" >12382</th>\n",
+       "      <td id=\"T_f7312_row5_col0\" class=\"data row5 col0\" >2022-03-28 01:27:37.798000+00:00</td>\n",
+       "      <td id=\"T_f7312_row5_col1\" class=\"data row5 col1\" >consumerfinancialprotectionbureau.gov</td>\n",
+       "      <td id=\"T_f7312_row5_col2\" class=\"data row5 col2\" >None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_f7312_level0_row6\" class=\"row_heading level0 row6\" >15223</th>\n",
+       "      <td id=\"T_f7312_row6_col0\" class=\"data row6 col0\" >2022-03-30 18:16:14.823000+00:00</td>\n",
+       "      <td id=\"T_f7312_row6_col1\" class=\"data row6 col1\" >cfpa.gov</td>\n",
+       "      <td id=\"T_f7312_row6_col2\" class=\"data row6 col2\" >https://www.consumerfinance.gov/</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_f7312_level0_row7\" class=\"row_heading level0 row7\" >14938</th>\n",
+       "      <td id=\"T_f7312_row7_col0\" class=\"data row7 col0\" >2022-03-31 00:22:21.041000+00:00</td>\n",
+       "      <td id=\"T_f7312_row7_col1\" class=\"data row7 col1\" >cfpb.gov</td>\n",
+       "      <td id=\"T_f7312_row7_col2\" class=\"data row7 col2\" >https://www.consumerfinance.gov/</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_f7312_level0_row8\" class=\"row_heading level0 row8\" >2926</th>\n",
+       "      <td id=\"T_f7312_row8_col0\" class=\"data row8 col0\" >2022-04-03 00:45:21.434000+00:00</td>\n",
+       "      <td id=\"T_f7312_row8_col1\" class=\"data row8 col1\" >id.wip.nlm.nih.gov</td>\n",
+       "      <td id=\"T_f7312_row8_col2\" class=\"data row8 col2\" >https://id.wip.nlm.nih.gov/mesh/</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_f7312_level0_row9\" class=\"row_heading level0 row9\" >8161</th>\n",
+       "      <td id=\"T_f7312_row9_col0\" class=\"data row9 col0\" >2022-04-03 00:49:11.138000+00:00</td>\n",
+       "      <td id=\"T_f7312_row9_col1\" class=\"data row9 col1\" >maps2.coast.noaa.gov</td>\n",
+       "      <td id=\"T_f7312_row9_col2\" class=\"data row9 col2\" >https://maps2.coast.noaa.gov/</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<pandas.io.formats.style.Styler at 0x126201b50>"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "last_scan_date = snapshot_df['scan_date'].max()\n",
+    "fresh_scan_date = last_scan_date - timedelta(days=1)\n",
+    "older_scans = snapshot_df.query('scan_date < @fresh_scan_date')[['scan_date', 'target_url', 'final_url']].sort_values('scan_date')\n",
+    "older_scans[:10].style.set_caption(f'Ten oldest scans before {fresh_scan_date}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Domains not in the target URL list:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "set()"
+      ]
+     },
+     "execution_count": 75,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print('Domains not in the target URL list:')\n",
+    "set(older_scans['target_url']) - set(target_url_df['website'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "31861831c0aff7abfdcad6f9ac5c6385ec60e4234f47271a24943534a2765fde"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.9.7 64-bit ('3.9.7')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Fix issue where undefined error messages lead to scan results not being saved to the database. See: https://github.com/GSA/site-scanning/issues/201

Also, add Jupyter notebook to compare domains with old scan dates against the target URL list. This is a useful way to analyze data and seems worth checking in for future analysis/debugging work.