### PR TITLE
Cleanup on ingest

### DIFF
--- a/apps/cli/src/ingest.controller.spec.ts
+++ b/apps/cli/src/ingest.controller.spec.ts
@@ -24,9 +24,10 @@ describe('IngestController', () => {
   });
 
   describe('root', () => {
-    it('should writes Urls', async () => {
-      await ingestController.writeUrls();
+    it('should refresh Urls', async () => {
+      await ingestController.refreshUrls();
       expect(mockIngestService.writeUrls).toHaveBeenCalled();
+      expect(mockIngestService.removeOldUrls).toHaveBeenCalled();
     });
   });
 });

--- a/apps/cli/src/ingest.controller.spec.ts
+++ b/apps/cli/src/ingest.controller.spec.ts
@@ -27,7 +27,6 @@ describe('IngestController', () => {
     it('should refresh Urls', async () => {
       await ingestController.refreshUrls();
       expect(mockIngestService.writeUrls).toHaveBeenCalled();
-      expect(mockIngestService.removeOldUrls).toHaveBeenCalled();
     });
   });
 });

--- a/apps/cli/src/ingest.controller.ts
+++ b/apps/cli/src/ingest.controller.ts
@@ -9,6 +9,5 @@ export class IngestController {
   async refreshUrls(limit?: number) {
     const urls = await this.ingestService.getUrls();
     await this.ingestService.writeUrls(urls, limit);
-    await this.ingestService.removeOldUrls(urls);
   }
 }

--- a/apps/cli/src/ingest.controller.ts
+++ b/apps/cli/src/ingest.controller.ts
@@ -6,8 +6,9 @@ import { IngestService } from '@app/ingest';
 export class IngestController {
   constructor(private readonly ingestService: IngestService) {}
 
-  async writeUrls(limit?: number) {
+  async refreshUrls(limit?: number) {
     const urls = await this.ingestService.getUrls();
     await this.ingestService.writeUrls(urls, limit);
+    await this.ingestService.removeOldUrls(urls);
   }
 }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -33,9 +33,9 @@ async function ingest(cmdObj) {
   console.log('ingesting target urls');
 
   if (cmdObj.limit) {
-    await controller.writeUrls(cmdObj.limit);
+    await controller.refreshUrls(cmdObj.limit);
   } else {
-    await controller.writeUrls();
+    await controller.refreshUrls();
   }
   printMemoryUsage();
   await nestApp.close();

--- a/entities/core-result.entity.ts
+++ b/entities/core-result.entity.ts
@@ -39,7 +39,9 @@ export class CoreResult {
   @Expose({ name: 'scan_date' })
   updated: string;
 
-  @OneToOne(() => Website, (website) => website.coreResult)
+  @OneToOne(() => Website, (website) => website.coreResult, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn()
   @Exclude({ toPlainOnly: true })
   website: Website;

--- a/entities/website.entity.ts
+++ b/entities/website.entity.ts
@@ -23,7 +23,9 @@ export class Website {
   @Exclude({ toPlainOnly: true })
   updated: string;
 
-  @OneToOne(() => CoreResult, (coreResult) => coreResult.website)
+  @OneToOne(() => CoreResult, (coreResult) => coreResult.website, {
+    onDelete: 'CASCADE',
+  })
   @Exclude({ toPlainOnly: true })
   coreResult: CoreResult;
 

--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Website } from 'entities/website.entity';
-import { Repository } from 'typeorm';
+import { LessThanOrEqual, Repository } from 'typeorm';
 import { CreateWebsiteDto } from './dto/create-website.dto';
 import {
   IPaginationOptions,
@@ -28,6 +28,16 @@ export class WebsiteService {
   async findAllWebsites(): Promise<Website[]> {
     const result = await this.website.find();
     return result;
+  }
+
+  async findNewestWebsite(): Promise<Website> {
+    const result = await this.website.find({
+      skip: 0,
+      take: 1,
+      order: { updated: 'DESC' },
+    });
+
+    return result[0];
   }
 
   async paginatedFilter(
@@ -132,11 +142,13 @@ export class WebsiteService {
     }
   }
 
-  async delete(id: number) {
-    await this.website
+  async deleteBefore(date: Date) {
+    return await this.website
       .createQueryBuilder('website')
       .delete()
-      .where('id = :id', { id: id })
+      .where({
+        updated: LessThanOrEqual(date.toISOString()),
+      })
       .execute();
   }
 }

--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -37,7 +37,11 @@ export class WebsiteService {
       order: { updated: 'DESC' },
     });
 
-    return result[0];
+    if (Array.isArray(result)) {
+      return result[0];
+    }
+
+    return result;
   }
 
   async paginatedFilter(

--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -131,4 +131,12 @@ export class WebsiteService {
       await this.website.insert(website);
     }
   }
+
+  async delete(id: number) {
+    await this.website
+      .createQueryBuilder('website')
+      .delete()
+      .where('id = :id', { id: id })
+      .execute();
+  }
 }

--- a/libs/ingest/src/ingest.service.spec.ts
+++ b/libs/ingest/src/ingest.service.spec.ts
@@ -3,7 +3,6 @@ import { HttpService } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { mock, MockProxy } from 'jest-mock-extended';
 import { IngestService } from './ingest.service';
-import { Website } from 'entities/website.entity';
 
 describe('IngestService', () => {
   let service: IngestService;
@@ -32,66 +31,5 @@ describe('IngestService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
-  });
-
-  describe('getInvalidWebsiteIds', () => {
-    it('gets the id for a website with an invalid url', () => {
-      const firstWebsite = new Website();
-      const secondWebsite = new Website();
-      const thirdWebsite = new Website();
-      firstWebsite.id = 1;
-      firstWebsite.url = 'foo.gov';
-      secondWebsite.id = 2;
-      secondWebsite.url = 'bar.gov';
-      thirdWebsite.id = 3;
-      thirdWebsite.url = 'baz.gov';
-      const currentWebsites = [firstWebsite, secondWebsite, thirdWebsite];
-      const validUrls = ['foo.gov', 'bar.gov'];
-
-      const result = service.getInvalidWebsiteIds(currentWebsites, validUrls);
-
-      expect(result).toEqual([3]);
-    });
-
-    it('gets the ids for multiple websites with invalid urls', () => {
-      const firstWebsite = new Website();
-      const secondWebsite = new Website();
-      const thirdWebsite = new Website();
-      const fourthWebsite = new Website();
-      firstWebsite.id = 1;
-      firstWebsite.url = 'foo.gov';
-      secondWebsite.id = 2;
-      secondWebsite.url = 'bar.gov';
-      thirdWebsite.id = 3;
-      thirdWebsite.url = 'baz.gov';
-      fourthWebsite.id = 4;
-      fourthWebsite.url = 'buzz.gov';
-      const currentWebsites = [
-        firstWebsite,
-        secondWebsite,
-        thirdWebsite,
-        fourthWebsite,
-      ];
-      const validUrls = ['foo.gov', 'bar.gov'];
-
-      const result = service.getInvalidWebsiteIds(currentWebsites, validUrls);
-
-      expect(result).toEqual([3, 4]);
-    });
-
-    it('returns an empty array if there are no websites with invalid urls', () => {
-      const firstWebsite = new Website();
-      const secondWebsite = new Website();
-      firstWebsite.id = 1;
-      firstWebsite.url = 'foo.gov';
-      secondWebsite.id = 2;
-      secondWebsite.url = 'bar.gov';
-      const currentWebsites = [firstWebsite, secondWebsite];
-      const validUrls = ['foo.gov', 'bar.gov'];
-
-      const result = service.getInvalidWebsiteIds(currentWebsites, validUrls);
-
-      expect(result).toEqual([]);
-    });
   });
 });

--- a/libs/ingest/src/ingest.service.spec.ts
+++ b/libs/ingest/src/ingest.service.spec.ts
@@ -3,6 +3,7 @@ import { HttpService } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { mock, MockProxy } from 'jest-mock-extended';
 import { IngestService } from './ingest.service';
+import { Website } from 'entities/website.entity';
 
 describe('IngestService', () => {
   let service: IngestService;
@@ -31,5 +32,66 @@ describe('IngestService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('getInvalidWebsiteIds', () => {
+    it('gets the id for a website with an invalid url', () => {
+      const firstWebsite = new Website();
+      const secondWebsite = new Website();
+      const thirdWebsite = new Website();
+      firstWebsite.id = 1;
+      firstWebsite.url = 'foo.gov';
+      secondWebsite.id = 2;
+      secondWebsite.url = 'bar.gov';
+      thirdWebsite.id = 3;
+      thirdWebsite.url = 'baz.gov';
+      const currentWebsites = [firstWebsite, secondWebsite, thirdWebsite];
+      const validUrls = ['foo.gov', 'bar.gov'];
+
+      const result = service.getInvalidWebsiteIds(currentWebsites, validUrls);
+
+      expect(result).toEqual([3]);
+    });
+
+    it('gets the ids for multiple websites with invalid urls', () => {
+      const firstWebsite = new Website();
+      const secondWebsite = new Website();
+      const thirdWebsite = new Website();
+      const fourthWebsite = new Website();
+      firstWebsite.id = 1;
+      firstWebsite.url = 'foo.gov';
+      secondWebsite.id = 2;
+      secondWebsite.url = 'bar.gov';
+      thirdWebsite.id = 3;
+      thirdWebsite.url = 'baz.gov';
+      fourthWebsite.id = 4;
+      fourthWebsite.url = 'buzz.gov';
+      const currentWebsites = [
+        firstWebsite,
+        secondWebsite,
+        thirdWebsite,
+        fourthWebsite,
+      ];
+      const validUrls = ['foo.gov', 'bar.gov'];
+
+      const result = service.getInvalidWebsiteIds(currentWebsites, validUrls);
+
+      expect(result).toEqual([3, 4]);
+    });
+
+    it('returns an empty array if there are no websites with invalid urls', () => {
+      const firstWebsite = new Website();
+      const secondWebsite = new Website();
+      firstWebsite.id = 1;
+      firstWebsite.url = 'foo.gov';
+      secondWebsite.id = 2;
+      secondWebsite.url = 'bar.gov';
+      const currentWebsites = [firstWebsite, secondWebsite];
+      const validUrls = ['foo.gov', 'bar.gov'];
+
+      const result = service.getInvalidWebsiteIds(currentWebsites, validUrls);
+
+      expect(result).toEqual([]);
+    });
   });
 });

--- a/libs/ingest/src/ingest.service.ts
+++ b/libs/ingest/src/ingest.service.ts
@@ -30,35 +30,6 @@ export class IngestService {
   }
 
   /**
-   * writeToDatabase writes a CSV to the database.
-   * @param row a CreateWebsiteDto object.
-   */
-  async writeToDatabase(row: CreateWebsiteDto) {
-    try {
-      await this.websiteService.create(row);
-    } catch (error) {
-      const err = error as Error;
-      this.logger.error(
-        `encountered error saving to database: ${err.message}`,
-        err.stack,
-      );
-    }
-  }
-
-  async removeFromDatabase(id: number) {
-    try {
-      await this.websiteService.delete(id);
-      this.logger.debug(`deleted website id ${id}`);
-    } catch (error) {
-      const err = error as Error;
-      this.logger.error(
-        `encountered error deleting from database: ${err.message}`,
-        err.stack,
-      );
-    }
-  }
-
-  /**
    * writeUrls writes target urls to the Websites table.
    */
   async writeUrls(urls: string, maxRows?: number) {
@@ -174,6 +145,40 @@ export class IngestService {
     });
 
     return end;
+  }
+
+  /**
+   * writeToDatabase writes a CSV to the database.
+   * @param row a CreateWebsiteDto object.
+   */
+  async writeToDatabase(row: CreateWebsiteDto) {
+    try {
+      await this.websiteService.create(row);
+    } catch (error) {
+      const err = error as Error;
+      this.logger.error(
+        `encountered error saving to database: ${err.message}`,
+        err.stack,
+      );
+    }
+  }
+
+  /**
+   * removeFromDatabase removes a website and its
+   * corresponding scan result from the datatabase.
+   * @param id given Website's primary key.
+   */
+  async removeFromDatabase(id: number) {
+    try {
+      await this.websiteService.delete(id);
+      this.logger.debug(`deleted website id ${id}`);
+    } catch (error) {
+      const err = error as Error;
+      this.logger.error(
+        `encountered error deleting from database: ${err.message}`,
+        err.stack,
+      );
+    }
   }
 
   getInvalidWebsiteIds(

--- a/libs/ingest/src/ingest.service.ts
+++ b/libs/ingest/src/ingest.service.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash';
 import { parse } from '@fast-csv/parse';
 import { HttpService, Injectable, Logger } from '@nestjs/common';
 import { map } from 'rxjs/operators';

--- a/libs/ingest/src/ingest.service.ts
+++ b/libs/ingest/src/ingest.service.ts
@@ -129,13 +129,17 @@ export class IngestService {
             validUrls,
           );
 
-          this.logger.debug(
-            `number of websites flagged for removal from the database: ${idsToDelete.length}`,
-          );
+          if (idsToDelete.length > 0) {
+            this.logger.debug(
+              `number of websites flagged for removal from the database: ${idsToDelete.length}`,
+            );
 
-          await Promise.all(idsToDelete);
+            await Promise.all(
+              idsToDelete.map((id) => this.removeFromDatabase(id)),
+            );
 
-          this.logger.debug('finished removing old urls');
+            this.logger.debug('finished removing old urls');
+          }
         } catch (err) {
           this.logger.error(err.message, err.stack);
         }
@@ -181,15 +185,23 @@ export class IngestService {
     }
   }
 
+  /**
+   * getInvalidWebsiteIds compares an array of websites
+   * agaist an array of valid urls and returns an array
+   * containing the ids of any websites that do not have
+   * a valid url.
+   * @param currentWebsites array of Websites.
+   * @param validUrls array of valid urls.
+   */
   getInvalidWebsiteIds(
     currentWebsites: Website[],
     validUrls: string[],
-  ): Promise<any>[] {
-    const idsToDelete: Promise<any>[] = [];
+  ): number[] {
+    const idsToDelete = [];
 
     for (let i = 0; i < currentWebsites.length; i++) {
       if (!validUrls.includes(currentWebsites[i]['url'])) {
-        idsToDelete.push(this.removeFromDatabase(currentWebsites[i]['id']));
+        idsToDelete.push(currentWebsites[i]['id']);
       }
     }
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -26,3 +26,4 @@ applications:
     health-check-type: process
     env:
       OPTIMIZE_MEMORY: true
+      TZ: UTC

--- a/notebooks/scan-result-quantity-analysis.ipynb
+++ b/notebooks/scan-result-quantity-analysis.ipynb
@@ -1,0 +1,112 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Scan result quantity analysis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Context\n",
+    "\n",
+    "See GitHub issue: https://github.com/GSA/site-scanning/issues/246"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "%pip install --quiet pandas jinja2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                        target_url  count\n",
+      "28123                      ihs.gov      2\n",
+      "10911         consumersentinel.gov      2\n",
+      "41426                      oge.gov      2\n",
+      "4683           ayudaconmibanco.gov      2\n",
+      "55326                      stb.gov      2\n",
+      "...                            ...    ...\n",
+      "27216      hydrology2.nws.noaa.gov      1\n",
+      "27215  hydrology.sci.gsfc.nasa.gov      1\n",
+      "27214           hydrology.pnnl.gov      1\n",
+      "27213            hydrology.pnl.gov      1\n",
+      "81288           •lihtc.huduser.gov      1\n",
+      "\n",
+      "[81289 rows x 2 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "snapshot_df = pd.read_json('https://api.gsa.gov/technology/site-scanning/data/weekly-snapshot.json')\n",
+    "target_url_df = pd.read_csv('https://raw.githubusercontent.com/GSA/federal-website-index/main/data/site-scanning-target-url-list.csv')\n",
+    "# print('Number of domains not in the target URL list:')\n",
+    "# len(set(snapshot_df['target_url']) - set(target_url_df['website']))\n",
+    "\n",
+    "df = snapshot_df.groupby(by=['target_url']).size().reset_index(name='count')\n",
+    "print(df[['target_url', 'count']].sort_values(by='count', ascending=False).drop_duplicates())\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.8.9 64-bit",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.9"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Issue: https://github.com/GSA/site-scanning/issues/129

Goal: The `website` and `core_results` database tables should only include websites that are listed in the CSV file of valid website URLs.

Solution: The CLI app's `ingest` command now removes extraneous websites from the database after ingesting the current CSV list of websites by calling the ingest service's new `removeOldUrls` method. 