### PR TITLE
Update ingest CLI to accept optional url argument

### DIFF
--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -8,11 +8,9 @@ on:
         description: deployed cloud.gov space
         required: true
         default: prod
-#        federalSubdomainsUrl:
-#          description: CSV with domain list
-#          required: true
-# yamllint disable-line rule:line-length
-#          default: 'https://raw.githubusercontent.com/GSA/federal-website-index/main/data/site-scanning-target-url-list.csv'
+      federalSubdomainsUrl:
+        description: CSV with domain list (leave blank to use default)
+        required: false
 
 jobs:
   ingest:

--- a/apps/cli/src/ingest.controller.ts
+++ b/apps/cli/src/ingest.controller.ts
@@ -6,8 +6,8 @@ import { IngestService } from '@app/ingest';
 export class IngestController {
   constructor(private readonly ingestService: IngestService) {}
 
-  async refreshUrls(limit?: number) {
-    const urls = await this.ingestService.getUrls();
+  async refreshUrls(limit?: number, federalSubdomainsUrl?: string) {
+    const urls = await this.ingestService.getUrls(federalSubdomainsUrl);
     await this.ingestService.writeUrls(urls, limit);
   }
 }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -32,11 +32,7 @@ async function ingest(cmdObj) {
   const controller = nestApp.get(IngestController);
   console.log('ingesting target urls');
 
-  if (cmdObj.limit) {
-    await controller.refreshUrls(cmdObj.limit);
-  } else {
-    await controller.refreshUrls();
-  }
+  await controller.refreshUrls(cmdObj.limit, cmdObj.federalSubdomainsUrl);
   printMemoryUsage();
   await nestApp.close();
 }
@@ -96,6 +92,10 @@ async function main() {
       '--limit <number>',
       'limits the ingest service to <number> urls',
       parseInt,
+    )
+    .option(
+      '--federalSubdomainsUrl <string>',
+      'URL pointing to CSV of federal subdomains',
     )
     .action(ingest);
 

--- a/libs/ingest/src/config/ingest.config.ts
+++ b/libs/ingest/src/config/ingest.config.ts
@@ -1,0 +1,6 @@
+export default () => {
+  return {
+    federalSubdomainsUrl:
+      'https://raw.githubusercontent.com/GSA/federal-website-index/main/data/site-scanning-target-url-list.csv',
+  };
+};

--- a/libs/ingest/src/ingest.module.ts
+++ b/libs/ingest/src/ingest.module.ts
@@ -2,9 +2,18 @@ import { DatabaseModule } from '@app/database';
 import { WebsiteModule } from '@app/database/websites/website.module';
 import { HttpModule, Module } from '@nestjs/common';
 import { IngestService } from './ingest.service';
+import { ConfigModule } from '@nestjs/config';
+import ingestConfig from './config/ingest.config';
 
 @Module({
-  imports: [HttpModule, WebsiteModule, DatabaseModule],
+  imports: [
+    HttpModule,
+    WebsiteModule,
+    DatabaseModule,
+    ConfigModule.forRoot({
+      load: [ingestConfig],
+    }),
+  ],
   providers: [IngestService],
   exports: [IngestService],
 })

--- a/libs/ingest/src/ingest.service.spec.ts
+++ b/libs/ingest/src/ingest.service.spec.ts
@@ -3,15 +3,17 @@ import { HttpService } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { mock, MockProxy } from 'jest-mock-extended';
 import { IngestService } from './ingest.service';
+import { ConfigService } from '@nestjs/config';
 
 describe('IngestService', () => {
   let service: IngestService;
   let mockHttpService: MockProxy<HttpService>;
   let mockWebsiteService: MockProxy<WebsiteService>;
-
+  let mockConfigService: MockProxy<ConfigService>;
   beforeEach(async () => {
     mockHttpService = mock<HttpService>();
     mockWebsiteService = mock<WebsiteService>();
+    mockConfigService = mock<ConfigService>();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         IngestService,
@@ -22,6 +24,10 @@ describe('IngestService', () => {
         {
           provide: HttpService,
           useValue: mockHttpService,
+        },
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
         },
       ],
     }).compile();

--- a/libs/ingest/src/ingest.service.ts
+++ b/libs/ingest/src/ingest.service.ts
@@ -1,6 +1,7 @@
 import { parse } from '@fast-csv/parse';
 import { HttpService, Injectable, Logger } from '@nestjs/common';
 import { map } from 'rxjs/operators';
+import { ConfigService } from '@nestjs/config';
 
 import { CreateWebsiteDto } from '@app/database/websites/dto/create-website.dto';
 import { WebsiteService } from '@app/database/websites/websites.service';
@@ -14,14 +15,17 @@ export class IngestService {
   constructor(
     private httpService: HttpService,
     private websiteService: WebsiteService,
+    private configService: ConfigService,
   ) {}
 
-  private currentFederalSubdomains =
-    'https://raw.githubusercontent.com/GSA/federal-website-index/main/data/site-scanning-target-url-list.csv';
+  private currentFederalSubdomains = this.configService.get<string>(
+    'federalSubdomainsUrl',
+  );
 
-  async getUrls(): Promise<string> {
+  async getUrls(url?: string): Promise<string> {
+    const urlList = url ?? this.currentFederalSubdomains;
     const urls = await this.httpService
-      .get(this.currentFederalSubdomains)
+      .get(urlList)
       .pipe(map((resp) => resp.data))
       .toPromise();
     return urls;


### PR DESCRIPTION
This PR lets users override the default list of valid federal subdomains when prompting the system to ingest that list.

- Moved hard-coded URL for list of valid federal subdomains to a config file for the `ingest` feature
- Users can pass an optional `url` argument to the CLI's `ingest` action
- This argument can also be passed by way of the **Ingest website list** GitHub action