### PR TITLE
Add documentation for ingest library

### DIFF
--- a/docs/libraries/ingest.md
+++ b/docs/libraries/ingest.md
@@ -1,0 +1,16 @@
+# Ingest Library
+
+The [ingest](../libs/ingest) library is responsible for ingesting a list of
+valid federal subdomains into the system.
+
+## Configuration
+
+The ingest library's [configuration file](../libs/ingest/src/config/ingest.config.ts)
+specifies a URL that points to a CSV file containing valid federal subdomains.
+
+## Use
+
+[The CLI's](../apps/cli) `ingest` command will retrieve data from the URL listed
+in the ingest library's configuration file. CLI users can override the default
+URL by passing a different `url` argument to the `ingest` command (e.g.,
+`--url=<a_different_url>`).


### PR DESCRIPTION
Related Issue: https://github.com/GSA/site-scanning/issues/109

Added documentation specifying exactly where the default URL for the list of valid federal subdomains lives in the ingest library, and how to override that default.