### PR TITLE
Login scan

### DIFF
--- a/entities/core-result.entity.ts
+++ b/entities/core-result.entity.ts
@@ -297,6 +297,10 @@ export class CoreResult {
   @Expose({ name: 'dns_ipv6' })
   dnsIpv6?: boolean;
 
+  @Column({ nullable: true })
+  @Expose({ name: 'login_detected' })
+  loginDetected?: string;
+
   static getColumnNames(): string[] {
     // return class-transformer version of column names
     return Object.keys(classToPlain(new CoreResult()));

--- a/entities/scan-data.entity.ts
+++ b/entities/scan-data.entity.ts
@@ -80,5 +80,5 @@ export type DnsScan = {
 };
 
 export type LoginScan = {
-  loginDetected: string[];
+  loginDetected: string;
 };

--- a/entities/scan-data.entity.ts
+++ b/entities/scan-data.entity.ts
@@ -78,3 +78,7 @@ export type NotFoundScan = {
 export type DnsScan = {
   ipv6: boolean;
 };
+
+export type LoginScan = {
+  loginDetected: string[];
+};

--- a/entities/scan-page.entity.ts
+++ b/entities/scan-page.entity.ts
@@ -18,6 +18,7 @@ export type PrimaryScans = {
   seoScan: ScanData.SeoScan;
   thirdPartyScan: ScanData.ThirdPartyScan;
   uswdsScan: ScanData.UswdsScan;
+  loginScan: ScanData.LoginScan;
 };
 export type PrimaryScan = PageScan<PrimaryScans>;
 

--- a/libs/core-scanner/src/pages/primary.spec.ts
+++ b/libs/core-scanner/src/pages/primary.spec.ts
@@ -66,6 +66,9 @@ describe('primary scanner', () => {
         dapDetected: false,
         dapParameters: undefined,
       },
+      loginScan: {
+        loginDetected: null,
+      },
       seoScan: {
         mainElementFinalUrl: true,
         ogArticleModifiedFinalUrl: time,

--- a/libs/core-scanner/src/pages/primary.ts
+++ b/libs/core-scanner/src/pages/primary.ts
@@ -10,6 +10,7 @@ import { buildDapResult } from '../scans/dap';
 import { buildSeoResult } from '../scans/seo';
 import { buildThirdPartyResult } from '../scans/third-party';
 import { createUswdsScanner } from '../scans/uswds';
+import { buildLoginResult } from '../scans/login';
 import { promiseAll, getHttpsUrl } from '../util';
 
 import {
@@ -40,12 +41,14 @@ const primaryScan = async (
     waitUntil: 'networkidle2',
   });
 
-  const [dapScan, thirdPartyScan, seoScan, uswdsScan] = await promiseAll([
-    buildDapResult(getOutboundRequests()),
-    buildThirdPartyResult(response, getOutboundRequests()),
-    buildSeoResult(logger, page),
-    createUswdsScanner({ logger, getCSSRequests }, page)(response),
-  ]);
+  const [dapScan, thirdPartyScan, seoScan, uswdsScan, loginScan] =
+    await promiseAll([
+      buildDapResult(getOutboundRequests()),
+      buildThirdPartyResult(response, getOutboundRequests()),
+      buildSeoResult(logger, page),
+      createUswdsScanner({ logger, getCSSRequests }, page)(response),
+      buildLoginResult(response),
+    ]);
   const urlScan = buildUrlScanResult(input, page, response);
 
   return {
@@ -54,5 +57,6 @@ const primaryScan = async (
     seoScan,
     thirdPartyScan,
     uswdsScan,
+    loginScan,
   };
 };

--- a/libs/core-scanner/src/scans/login.spec.ts
+++ b/libs/core-scanner/src/scans/login.spec.ts
@@ -1,0 +1,24 @@
+import { mock } from 'jest-mock-extended';
+import { HTTPResponse } from 'puppeteer';
+
+import { buildLoginResult } from './login';
+
+describe('login scan', () => {
+  it('Detects login strings', async () => {
+    const html = `
+      <form>
+        <input type="password"></input>
+      </form>
+    `;
+
+    expect(
+      await buildLoginResult(
+        mock<HTTPResponse>({
+          text: async () => html,
+        }),
+      ),
+    ).toEqual({
+      loginDetected: ['"password"', 'type="password"'],
+    });
+  });
+});

--- a/libs/core-scanner/src/scans/login.spec.ts
+++ b/libs/core-scanner/src/scans/login.spec.ts
@@ -17,8 +17,6 @@ describe('login scan', () => {
           text: async () => html,
         }),
       ),
-    ).toEqual({
-      loginDetected: ['"password"', 'type="password"'],
-    });
+    ).toEqual({ loginDetected: '"password",type="password"' });
   });
 });

--- a/libs/core-scanner/src/scans/login.ts
+++ b/libs/core-scanner/src/scans/login.ts
@@ -32,6 +32,6 @@ export const buildLoginResult = async (
   });
 
   return {
-    loginDetected: result.sort(),
+    loginDetected: result.sort().join(','),
   };
 };

--- a/libs/core-scanner/src/scans/login.ts
+++ b/libs/core-scanner/src/scans/login.ts
@@ -1,0 +1,37 @@
+import { HTTPResponse } from 'puppeteer';
+
+import { LoginScan } from 'entities/scan-data.entity';
+
+const loginStrings = [
+  'type="password"',
+  '>Sign In<',
+  'id="new_user"',
+  '"forgot_your_password"',
+  'Forgot your Password?',
+  '>Show Password</a>',
+  '"user_password"',
+  '"user_email"',
+  '>Forgot Password</a>',
+  '>Forgot User ID</a>',
+  'showpassword',
+  'Create Account',
+  '"userid"',
+  '"password"',
+];
+
+export const buildLoginResult = async (
+  mainResponse: HTTPResponse,
+): Promise<LoginScan> => {
+  const result = [];
+  const html = await mainResponse.text();
+
+  loginStrings.forEach((string) => {
+    if (html.includes(string)) {
+      result.push(string);
+    }
+  });
+
+  return {
+    loginDetected: result.sort(),
+  };
+};

--- a/libs/core-scanner/src/scans/login.ts
+++ b/libs/core-scanner/src/scans/login.ts
@@ -26,12 +26,12 @@ export const buildLoginResult = async (
   const html = await mainResponse.text();
 
   loginStrings.forEach((string) => {
-    if (html.includes(string)) {
+    if (html.toLowerCase().includes(string.toLowerCase())) {
       result.push(string);
     }
   });
 
   return {
-    loginDetected: result.sort().join(','),
+    loginDetected: result.length > 0 ? result.sort().join(',') : null,
   };
 };

--- a/libs/core-scanner/test/app.e2e-spec.ts
+++ b/libs/core-scanner/test/app.e2e-spec.ts
@@ -45,6 +45,9 @@ describe('CoreScanner (e2e)', () => {
                 ? result.primary.result.dapScan.dapParameters
                 : undefined, // need to fix this eventually
           },
+          loginScan: {
+            loginDetected: null,
+          },
           seoScan: {
             mainElementFinalUrl: true,
             ogArticleModifiedFinalUrl: undefined,
@@ -173,6 +176,9 @@ describe('CoreScanner (e2e)', () => {
               result.primary.status === ScanStatus.Completed
                 ? result.primary.result.dapScan.dapParameters
                 : undefined, // need to fix this eventually
+          },
+          loginScan: {
+            loginDetected: null,
           },
           seoScan: {
             mainElementFinalUrl: false,

--- a/libs/database/src/core-results/core-result.service.ts
+++ b/libs/database/src/core-results/core-result.service.ts
@@ -96,6 +96,9 @@ export class CoreResultService {
       coreResult.uswdsSemanticVersion = result.uswdsScan.uswdsSemanticVersion;
       coreResult.uswdsVersion = result.uswdsScan.uswdsVersion;
       coreResult.uswdsCount = result.uswdsScan.uswdsCount;
+
+      // Login scan
+      coreResult.loginDetected = result.loginScan.loginDetected;
     }
 
     coreResult.notFoundScanStatus = pages.notFound.status;

--- a/libs/snapshot/src/snapshot.service.ts
+++ b/libs/snapshot/src/snapshot.service.ts
@@ -159,4 +159,5 @@ const CSV_COLUMN_ORDER = [
   'third_party_service_count',
   'dap_detected_final_url',
   'dap_parameters_final_url',
+  'login_detected',
 ];

--- a/libs/snapshot/src/snapshot.service.ts
+++ b/libs/snapshot/src/snapshot.service.ts
@@ -157,7 +157,7 @@ const CSV_COLUMN_ORDER = [
   'dns_ipv6',
   'third_party_service_domains',
   'third_party_service_count',
+  'login_detected',
   'dap_detected_final_url',
   'dap_parameters_final_url',
-  'login_detected',
 ];

--- a/libs/snapshot/src/snapshot.service.ts
+++ b/libs/snapshot/src/snapshot.service.ts
@@ -115,6 +115,9 @@ const CSV_COLUMN_ORDER = [
   'sitemap_xml_scan_status',
   'dns_scan_status',
   'dns_ipv6',
+  'source_list_federal_domains',
+  'source_list_dap',
+  'source_list_pulse',
   'uswds_favicon',
   'uswds_favicon_in_css',
   'uswds_merriweather_font',
@@ -156,7 +159,4 @@ const CSV_COLUMN_ORDER = [
   'third_party_service_count',
   'dap_detected_final_url',
   'dap_parameters_final_url',
-  'source_list_federal_domains',
-  'source_list_dap',
-  'source_list_pulse',
 ];


### PR DESCRIPTION
Issue: https://github.com/GSA/site-scanning/issues/233

Goal: Add a scan that checks for the inclusion of a login form in a given URL's HTML response body.

Solution: `primary` page scan includes a login scan.