### PR TITLE
Upgrade to nest/axios for http services

### DIFF
--- a/libs/core-scanner/src/core-scanner.module.ts
+++ b/libs/core-scanner/src/core-scanner.module.ts
@@ -1,5 +1,6 @@
 import { BrowserModule } from '@app/browser';
-import { HttpModule, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
 import { CoreScannerService } from './core-scanner.service';
 
 @Module({

--- a/libs/core-scanner/src/core-scanner.service.spec.ts
+++ b/libs/core-scanner/src/core-scanner.service.spec.ts
@@ -2,7 +2,7 @@ import { mock, MockProxy } from 'jest-mock-extended';
 import { Page, HTTPResponse, HTTPRequest, Browser } from 'puppeteer';
 import { getLoggerToken, PinoLogger } from 'nestjs-pino';
 import { of } from 'rxjs';
-import { HttpModule, HttpService } from '@nestjs/common';
+import { HttpModule, HttpService } from '@nestjs/axios';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { BrowserModule, BrowserService } from '@app/browser';

--- a/libs/core-scanner/src/core-scanner.service.ts
+++ b/libs/core-scanner/src/core-scanner.service.ts
@@ -1,10 +1,10 @@
-import { HttpService, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
 import { PinoLogger, InjectPinoLogger } from 'nestjs-pino';
 import { Logger } from 'pino';
 
 import { BrowserService } from '@app/browser';
 
-import { CoreResult } from 'entities/core-result.entity';
 import { parseBrowserError, ScanStatus } from 'entities/scan-status';
 import { Scanner } from 'libs/scanner.interface';
 

--- a/libs/core-scanner/src/pages/not-found.ts
+++ b/libs/core-scanner/src/pages/not-found.ts
@@ -1,4 +1,5 @@
-import { HttpService, HttpStatus } from '@nestjs/common';
+import { HttpStatus } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
 import { Agent } from 'https';
 import { v4 } from 'uuid';
 

--- a/libs/ingest/src/ingest.module.ts
+++ b/libs/ingest/src/ingest.module.ts
@@ -1,6 +1,7 @@
 import { DatabaseModule } from '@app/database';
 import { WebsiteModule } from '@app/database/websites/website.module';
-import { HttpModule, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
 import { IngestService } from './ingest.service';
 import { ConfigModule } from '@nestjs/config';
 import ingestConfig from './config/ingest.config';

--- a/libs/ingest/src/ingest.service.spec.ts
+++ b/libs/ingest/src/ingest.service.spec.ts
@@ -1,5 +1,5 @@
 import { WebsiteService } from '@app/database/websites/websites.service';
-import { HttpService } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
 import { Test, TestingModule } from '@nestjs/testing';
 import { mock, MockProxy } from 'jest-mock-extended';
 import { IngestService } from './ingest.service';

--- a/libs/ingest/src/ingest.service.ts
+++ b/libs/ingest/src/ingest.service.ts
@@ -1,5 +1,6 @@
 import { parse } from '@fast-csv/parse';
-import { HttpService, Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
 import { map } from 'rxjs/operators';
 import { ConfigService } from '@nestjs/config';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nestjs/axios": "^0.0.8",
         "@nestjs/bull": "^0.4.2",
         "@nestjs/common": "^8.2.6",
         "@nestjs/config": "^1.1.6",
@@ -1328,6 +1329,41 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@nestjs/axios": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-0.0.8.tgz",
+      "integrity": "sha512-oJyfR9/h9tVk776il0829xyj3b2e81yTu6HjPraxynwNtMNGqZBHHmAQL24yMB3tVbBM0RvG3eUXH8+pRCGwlg==",
+      "dependencies": {
+        "axios": "0.27.2"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0",
+        "reflect-metadata": "^0.1.12",
+        "rxjs": "^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@nestjs/axios/node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@nestjs/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@nestjs/bull": {
@@ -2996,7 +3032,6 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
@@ -3865,7 +3900,6 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -5020,7 +5054,6 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -14332,6 +14365,35 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@nestjs/axios": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-0.0.8.tgz",
+      "integrity": "sha512-oJyfR9/h9tVk776il0829xyj3b2e81yTu6HjPraxynwNtMNGqZBHHmAQL24yMB3tVbBM0RvG3eUXH8+pRCGwlg==",
+      "requires": {
+        "axios": "0.27.2"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+          "requires": {
+            "follow-redirects": "^1.14.9",
+            "form-data": "^4.0.0"
+          }
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@nestjs/bull": {
       "version": "0.4.2",
       "requires": {}
@@ -15432,8 +15494,7 @@
       "dev": true
     },
     "asynckit": {
-      "version": "0.4.0",
-      "dev": true
+      "version": "0.4.0"
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -15989,7 +16050,6 @@
     },
     "combined-stream": {
       "version": "1.0.8",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -16797,8 +16857,7 @@
       }
     },
     "delayed-stream": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "denque": {
       "version": "1.5.1"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand"
   },
   "dependencies": {
+    "@nestjs/axios": "^0.0.8",
     "@nestjs/bull": "^0.4.2",
     "@nestjs/common": "^8.2.6",
     "@nestjs/config": "^1.1.6",


### PR DESCRIPTION
Issue: https://github.com/GSA/site-scanning/issues/133

Install `nest/axios` and use the `HttpModule` and `HttpService` from that package instead of `nest/common`.