### PR TITLE
Update query for live snapshot

### DIFF
--- a/libs/database/src/websites/websites.service.integration.spec.ts
+++ b/libs/database/src/websites/websites.service.integration.spec.ts
@@ -34,7 +34,7 @@ describe('AnalysisService', () => {
     expect(service).toBeDefined();
   });
 
-  it('get only live website results', async () => {
+  it('get only live snapshot website results', async () => {
     const firstWebsite = new Website();
     firstWebsite.url = 'https://18f.gov';
     firstWebsite.branch = 'Federal Agency - Executive';
@@ -53,6 +53,15 @@ describe('AnalysisService', () => {
     secondWebsite.bureauCode = 10;
     secondWebsite.sourceList = 'gov';
 
+    const thirdWebsite = new Website();
+    thirdWebsite.url = 'https://anotherfake.gov';
+    thirdWebsite.branch = 'Federal Agency - Executive';
+    thirdWebsite.agency = 'Fake Agency';
+    thirdWebsite.bureau = 'GSA,FAS,Technology Transformation Service';
+    thirdWebsite.agencyCode = 10;
+    thirdWebsite.bureauCode = 10;
+    thirdWebsite.sourceList = 'gov';
+
     const firstCoreResult = new CoreResult();
     firstCoreResult.website = firstWebsite;
     firstCoreResult.finalUrlIsLive = true;
@@ -61,6 +70,7 @@ describe('AnalysisService', () => {
     firstCoreResult.robotsTxtScanStatus = 'complete';
     firstCoreResult.sitemapXmlScanStatus = 'complete';
     firstCoreResult.targetUrlBaseDomain = 'complete';
+    firstCoreResult.finalUrlMIMEType = 'text/html';
 
     const secondCoreResult = new CoreResult();
     secondCoreResult.website = secondWebsite;
@@ -70,13 +80,26 @@ describe('AnalysisService', () => {
     secondCoreResult.robotsTxtScanStatus = 'complete';
     secondCoreResult.sitemapXmlScanStatus = 'complete';
     secondCoreResult.targetUrlBaseDomain = 'complete';
+    secondCoreResult.finalUrlMIMEType = 'text/html';
+
+    const thirdCoreResult = new CoreResult();
+    thirdCoreResult.website = thirdWebsite;
+    thirdCoreResult.finalUrlIsLive = true;
+    thirdCoreResult.notFoundScanStatus = 'complete';
+    thirdCoreResult.primaryScanStatus = 'complete';
+    thirdCoreResult.robotsTxtScanStatus = 'complete';
+    thirdCoreResult.sitemapXmlScanStatus = 'complete';
+    thirdCoreResult.targetUrlBaseDomain = 'complete';
+    thirdCoreResult.finalUrlMIMEType = 'application/json';
 
     await websiteRepository.insert(firstWebsite);
     await coreResultRepository.insert(firstCoreResult);
     await websiteRepository.insert(secondWebsite);
     await coreResultRepository.insert(secondCoreResult);
+    await websiteRepository.insert(thirdWebsite);
+    await coreResultRepository.insert(thirdCoreResult);
 
-    const result = await service.findLiveWebsiteResults();
+    const result = await service.findLiveSnapshotWebsiteResults();
 
     expect(result.length).toStrictEqual(1);
   });

--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -25,14 +25,21 @@ export class WebsiteService {
     return websites;
   }
 
-  async findLiveWebsiteResults(): Promise<Website[]> {
-    const websites = this.website
+  async findLiveSnapshotWebsiteResults(): Promise<Website[]> {
+    const queryBuilder = this.website
       .createQueryBuilder('website')
       .innerJoinAndSelect('website.coreResult', 'coreResult')
       .where('coreResult.finalUrlIsLive = :isLive', { isLive: true })
-      .getMany();
+      .andWhere('coreResult.finalUrlMIMEType NOT IN (:...mimeTypes)', {
+        mimeTypes: [
+          'application/xhtml+xml',
+          'application/xml',
+          'application/json',
+          'text/xml',
+        ],
+      });
 
-    return websites;
+    return await queryBuilder.getMany();
   }
 
   async findAllWebsites(): Promise<Website[]> {

--- a/libs/snapshot/src/snapshot.service.spec.ts
+++ b/libs/snapshot/src/snapshot.service.spec.ts
@@ -77,12 +77,15 @@ describe('SnapshotService', () => {
     coreResult.primaryScanStatus = 'completed';
     coreResult.robotsTxtScanStatus = 'completed';
     coreResult.sitemapXmlScanStatus = 'completed';
+    coreResult.finalUrlMIMEType = 'text/html';
 
     const website = new Website();
     website.coreResult = coreResult;
     website.url = 'supremecourt.gov';
 
-    mockWebsiteService.findLiveWebsiteResults.mockResolvedValue([website]);
+    mockWebsiteService.findLiveSnapshotWebsiteResults.mockResolvedValue([
+      website,
+    ]);
     mockWebsiteService.findAllWebsiteResults.mockResolvedValue([website]);
 
     await service.weeklySnapshot();

--- a/libs/snapshot/src/snapshot.service.ts
+++ b/libs/snapshot/src/snapshot.service.ts
@@ -128,7 +128,7 @@ export class SnapshotService {
     const liveSnapshot = new Snapshot(
       this.storageService,
       [new JsonSerializer(liveColumnOrder), new CsvSerializer(liveColumnOrder)],
-      await this.websiteService.findLiveWebsiteResults(),
+      await this.websiteService.findLiveSnapshotWebsiteResults(),
       priorDate,
       this.fileNameLive,
     );


### PR DESCRIPTION
This PR updates the query that retrieves websites for the live snapshot to filter out entries that have a final_url_mimetype of any of the following:

- application/xhtml+xml
- application/xml
- application/json
- text/xml
