### PR TITLE
Add tld filter to website service

### DIFF
--- a/libs/database/src/websites/websites.service.integration.spec.ts
+++ b/libs/database/src/websites/websites.service.integration.spec.ts
@@ -34,7 +34,7 @@ describe('AnalysisService', () => {
     expect(service).toBeDefined();
   });
 
-  it('get only live snapshot website results', async () => {
+  it('get only live snapshot website results with the appropriate tld', async () => {
     const firstWebsite = new Website();
     firstWebsite.url = 'https://18f.gov';
     firstWebsite.topLevelDomain = 'gov';
@@ -64,6 +64,15 @@ describe('AnalysisService', () => {
     thirdWebsite.agencyCode = 10;
     thirdWebsite.bureauCode = 10;
     thirdWebsite.sourceList = 'gov';
+
+    const fourthWebsite = new Website();
+    fourthWebsite.url = 'https://anotherfake.com';
+    fourthWebsite.topLevelDomain = 'com';
+    fourthWebsite.branch = 'fake';
+    fourthWebsite.bureau = 'fake';
+    fourthWebsite.agencyCode = 10;
+    fourthWebsite.bureauCode = 10;
+    fourthWebsite.sourceList = '';
 
     const firstCoreResult = new CoreResult();
     firstCoreResult.website = firstWebsite;
@@ -95,6 +104,16 @@ describe('AnalysisService', () => {
     thirdCoreResult.targetUrlBaseDomain = 'complete';
     thirdCoreResult.finalUrlMIMEType = 'application/json';
 
+    const fourthCoreResult = new CoreResult();
+    fourthCoreResult.website = fourthWebsite;
+    fourthCoreResult.finalUrlIsLive = true;
+    fourthCoreResult.notFoundScanStatus = 'complete';
+    fourthCoreResult.primaryScanStatus = 'complete';
+    fourthCoreResult.robotsTxtScanStatus = 'complete';
+    fourthCoreResult.sitemapXmlScanStatus = 'complete';
+    fourthCoreResult.targetUrlBaseDomain = 'complete';
+    fourthCoreResult.finalUrlMIMEType = 'application/html';
+
     await websiteRepository.insert(firstWebsite);
     await coreResultRepository.insert(firstCoreResult);
     await websiteRepository.insert(secondWebsite);
@@ -102,7 +121,7 @@ describe('AnalysisService', () => {
     await websiteRepository.insert(thirdWebsite);
     await coreResultRepository.insert(thirdCoreResult);
 
-    const result = await service.findLiveSnapshotWebsiteResults();
+    const result = await service.findLiveSnapshotResults();
 
     expect(result.length).toStrictEqual(1);
   });

--- a/libs/database/src/websites/websites.service.spec.ts
+++ b/libs/database/src/websites/websites.service.spec.ts
@@ -5,7 +5,6 @@ import { mock } from 'jest-mock-extended';
 import { DeleteQueryBuilder, Repository, SelectQueryBuilder } from 'typeorm';
 import { CreateWebsiteDto } from './dto/create-website.dto';
 import { WebsiteService } from './websites.service';
-import { CoreResult } from 'entities/core-result.entity';
 
 describe('WebsiteService', () => {
   let service: WebsiteService;
@@ -32,15 +31,17 @@ describe('WebsiteService', () => {
     expect(service).toBeDefined();
   });
 
-  it('should return all Websites', async () => {
+  it('should return all Websites needed for the snapshot', async () => {
     const website = new Website();
     website.url = 'https://18f.gov';
+    website.topLevelDomain = 'gov';
 
     mockQB.innerJoinAndSelect.mockReturnThis();
+    mockQB.where.mockReturnThis();
     mockQB.getMany.mockResolvedValue([website]);
     mockRepository.createQueryBuilder.mockReturnValue(mockQB);
 
-    const result = await service.findAllWebsiteResults();
+    const result = await service.findAllSnapshotResults();
 
     const expected = [website];
     expect(result).toStrictEqual(expected);

--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -16,20 +16,22 @@ export class WebsiteService {
     @InjectRepository(Website) private website: Repository<Website>,
   ) {}
 
-  async findAllWebsiteResults(): Promise<Website[]> {
+  async findAllSnapshotResults(): Promise<Website[]> {
     const websites = this.website
       .createQueryBuilder('website')
       .innerJoinAndSelect('website.coreResult', 'coreResult')
+      .where('website.topLevelDomain = :tld', { tld: 'gov' })
       .getMany();
 
     return websites;
   }
 
-  async findLiveSnapshotWebsiteResults(): Promise<Website[]> {
+  async findLiveSnapshotResults(): Promise<Website[]> {
     const queryBuilder = this.website
       .createQueryBuilder('website')
       .innerJoinAndSelect('website.coreResult', 'coreResult')
-      .where('coreResult.finalUrlIsLive = :isLive', { isLive: true })
+      .where('website.topLevelDomain = :tld', { tld: 'gov' })
+      .andWhere('coreResult.finalUrlIsLive = :isLive', { isLive: true })
       .andWhere('coreResult.finalUrlMIMEType NOT IN (:...mimeTypes)', {
         mimeTypes: [
           'application/xhtml+xml',
@@ -67,7 +69,8 @@ export class WebsiteService {
   ): Promise<Pagination<Website>> {
     const query = this.website
       .createQueryBuilder('website')
-      .leftJoinAndSelect('website.coreResult', 'coreResult');
+      .leftJoinAndSelect('website.coreResult', 'coreResult')
+      .where('website.topLevelDomain = :tld', { tld: 'gov' });
 
     if (dto.target_url_domain) {
       query.andWhere('coreResult.targetUrlBaseDomain = :baseDomain', {

--- a/libs/snapshot/src/snapshot.service.spec.ts
+++ b/libs/snapshot/src/snapshot.service.spec.ts
@@ -83,10 +83,8 @@ describe('SnapshotService', () => {
     website.coreResult = coreResult;
     website.url = 'supremecourt.gov';
 
-    mockWebsiteService.findLiveSnapshotWebsiteResults.mockResolvedValue([
-      website,
-    ]);
-    mockWebsiteService.findAllWebsiteResults.mockResolvedValue([website]);
+    mockWebsiteService.findLiveSnapshotResults.mockResolvedValue([website]);
+    mockWebsiteService.findAllSnapshotResults.mockResolvedValue([website]);
 
     await service.weeklySnapshot();
 

--- a/libs/snapshot/src/snapshot.service.ts
+++ b/libs/snapshot/src/snapshot.service.ts
@@ -120,7 +120,7 @@ export class SnapshotService {
     const allSnapshot = new Snapshot(
       this.storageService,
       [new JsonSerializer(liveColumnOrder), new CsvSerializer(liveColumnOrder)],
-      await this.websiteService.findAllWebsiteResults(),
+      await this.websiteService.findAllSnapshotResults(),
       priorDate,
       this.fileNameAll,
     );
@@ -128,7 +128,7 @@ export class SnapshotService {
     const liveSnapshot = new Snapshot(
       this.storageService,
       [new JsonSerializer(liveColumnOrder), new CsvSerializer(liveColumnOrder)],
-      await this.websiteService.findLiveSnapshotWebsiteResults(),
+      await this.websiteService.findLiveSnapshotResults(),
       priorDate,
       this.fileNameLive,
     );
@@ -216,7 +216,7 @@ export class SnapshotService {
         new JsonSerializer(experimentalColumnOrder),
         new CsvSerializer(experimentalColumnOrder),
       ],
-      await this.websiteService.findAllWebsiteResults(),
+      await this.websiteService.findAllSnapshotResults(),
       priorDate,
       this.fileNameExperimental,
     );


### PR DESCRIPTION
This PR adds filters to the website service to ensure that only websites with a top level domain of 'gov' are returned.