### PR TITLE
Update dap scan to explicitly return null if dap parameters are not f…

### DIFF
--- a/libs/core-scanner/src/scans/dap.spec.ts
+++ b/libs/core-scanner/src/scans/dap.spec.ts
@@ -14,7 +14,7 @@ describe('dap scan', () => {
       ]),
     ).toEqual({
       dapDetected: true,
-      dapParameters: undefined,
+      dapParameters: null,
     });
   });
 
@@ -28,7 +28,7 @@ describe('dap scan', () => {
       ]),
     ).toEqual({
       dapDetected: true,
-      dapParameters: undefined,
+      dapParameters: null,
     });
   });
 
@@ -42,7 +42,7 @@ describe('dap scan', () => {
       ]),
     ).toEqual({
       dapDetected: true,
-      dapParameters: undefined,
+      dapParameters: null,
     });
   });
 

--- a/libs/core-scanner/src/scans/dap.ts
+++ b/libs/core-scanner/src/scans/dap.ts
@@ -8,7 +8,7 @@ export const buildDapResult = async (
 ): Promise<DapScan> => {
   const dapParameters = getDapParameters(outboundRequests);
   const dapDetected =
-    getDapDetected(outboundRequests) || typeof dapParameters !== 'undefined';
+    getDapDetected(outboundRequests) || dapParameters !== null;
 
   logger.info({
     msg: 'dapParameters result:',
@@ -26,7 +26,7 @@ export const buildDapResult = async (
   };
 };
 
-const getDapParameters = (outboundRequests: HTTPRequest[]): string => {
+const getDapParameters = (outboundRequests: HTTPRequest[]): string | null => {
   const dapScript = 'Universal-Federated-Analytics-Min.js';
   let parameters: string;
 
@@ -40,7 +40,7 @@ const getDapParameters = (outboundRequests: HTTPRequest[]): string => {
     }
   }
 
-  return parameters;
+  return typeof parameters === 'undefined' ? null : parameters;
 };
 
 /**


### PR DESCRIPTION
This PR updates the DAP scan to explicitly set the `dapParameters` field to `null` if no DAP parameters are found.