### PR TITLE
Core result entity update

### DIFF
--- a/entities/core-result.entity.ts
+++ b/entities/core-result.entity.ts
@@ -285,6 +285,13 @@ export class CoreResult {
 
   @Column({ nullable: true })
   @Expose({ name: 'cookie_domains' })
+  @Transform((value: string) => {
+    if (value) {
+      return value.split(',');
+    } else {
+      return null;
+    }
+  })
   cookieDomains?: string;
 
   @Column({ nullable: true })
@@ -293,6 +300,13 @@ export class CoreResult {
 
   @Column({ nullable: true })
   @Expose({ name: 'login_detected' })
+  @Transform((value: string) => {
+    if (value) {
+      return value.split(',');
+    } else {
+      return null;
+    }
+  })
   loginDetected?: string;
 
   @Column({ nullable: true })

--- a/libs/snapshot/src/serializers/json-serializer.spec.ts
+++ b/libs/snapshot/src/serializers/json-serializer.spec.ts
@@ -85,7 +85,7 @@ describe('JsonSerializer', () => {
 
     const result = serializer.serialize([website]);
     const expectedResult =
-      '[{"source_list":null,"required_links_url":null,"required_links_text":null,"robots_txt_sitemap_locations":null,"third_party_service_domains":null}]';
+      '[{"source_list":null,"required_links_url":null,"required_links_text":null,"robots_txt_sitemap_locations":null,"third_party_service_domains":null,"cookie_domains":null,"login_detected":null}]';
 
     expect(result).toEqual(expectedResult);
   });


### PR DESCRIPTION
https://github.com/GSA/site-scanning/issues/562

This PR updates two fields in the CoreResult entity class so that they are returned as arrays instead of comma-separated strings.
- cookie_domains
- login_detected