### PR TITLE
Fix method updating core result URL scan results

### DIFF
--- a/libs/database/src/core-results/core-result.service.ts
+++ b/libs/database/src/core-results/core-result.service.ts
@@ -156,6 +156,7 @@ export class CoreResultService {
       coreResult.finalUrl = null;
       coreResult.finalUrlBaseDomain = null;
       coreResult.finalUrlWebsite = null;
+      coreResult.finalUrlTopLevelDomain = null;
       coreResult.finalUrlIsLive = null;
       coreResult.finalUrlMIMEType = null;
       coreResult.finalUrlSameDomain = null;


### PR DESCRIPTION
Fix the method updating a core result scan's URL scan results to set `finalUrlTopLevelDomain` to `null` if the primary scan fails.