### PR TITLE
Implement basic security data integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ mega-linter.log
 
 # don't include Python virtual environment
 venv/
+
+# data for security scan
+/security-data

--- a/apps/cli/src/app.module.ts
+++ b/apps/cli/src/app.module.ts
@@ -6,11 +6,13 @@ import { DatabaseModule } from '@app/database';
 import { IngestModule } from '@app/ingest';
 import { QueueModule } from '@app/queue';
 import { SnapshotModule } from '@app/snapshot';
+import { SecurityDataModule } from '@app/security-data';
 
 import { IngestController } from './ingest.controller';
 import { QueueController } from './queue.controller';
 import { ScanController } from './scan.controller';
 import { SnapshotController } from './snapshot.controller';
+import { SecurityDataController } from './security-data.controller';
 
 @Module({
   imports: [
@@ -25,12 +27,14 @@ import { SnapshotController } from './snapshot.controller';
     }),
     QueueModule,
     SnapshotModule,
+    SecurityDataModule,
   ],
   controllers: [
     IngestController,
     QueueController,
     ScanController,
     SnapshotController,
+    SecurityDataController,
   ],
 })
 export class AppModule {}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -8,6 +8,7 @@ import { IngestController } from './ingest.controller';
 import { QueueController } from './queue.controller';
 import { ScanController } from './scan.controller';
 import { SnapshotController } from './snapshot.controller';
+import { SecurityDataController } from './security-data.controller';
 
 async function bootstrap() {
   const app = await NestFactory.createApplicationContext(AppModule, {
@@ -77,6 +78,16 @@ async function scanSite(cmdObj) {
   await nestApp.close();
 }
 
+async function securityData() {
+  const nestApp = await bootstrap();
+  const controller = nestApp.get(SecurityDataController);
+  console.log('fetching and saving security data');
+
+  await controller.fetchAndSaveSecurityData();
+  printMemoryUsage();
+  await nestApp.close();
+}
+
 async function main() {
   const program = new Command();
   program.version('0.0.1');
@@ -129,6 +140,14 @@ async function main() {
     )
     .option('--url <string>', 'URL to scan')
     .action(scanSite);
+
+  // security-data
+  program
+    .command('security-data')
+    .description(
+      'security-data fetches security data from a CSV and saves it to disk',
+    )
+    .action(securityData);
 
   await program.parseAsync(process.argv);
 }

--- a/apps/cli/src/security-data.controller.ts
+++ b/apps/cli/src/security-data.controller.ts
@@ -1,0 +1,12 @@
+import { Controller } from '@nestjs/common';
+
+import { SecurityDataService } from '@app/security-data';
+
+@Controller()
+export class SecurityDataController {
+  constructor(private readonly securityDataService: SecurityDataService) {}
+
+  async fetchAndSaveSecurityData() {
+    await this.securityDataService.fetchAndSaveSecurityData();
+  }
+}

--- a/entities/core-result.entity.ts
+++ b/entities/core-result.entity.ts
@@ -10,6 +10,7 @@ import {
 } from 'typeorm';
 
 import * as ScanPage from 'entities/scan-page.entity';
+import { SecurityScans } from 'entities/scan-page.entity';
 import { BaseScan } from './scan-data.entity';
 import { Website } from './website.entity';
 
@@ -23,6 +24,7 @@ export type CoreResultPages = {
   dns: ScanPage.DnsPageScan;
   accessibility: ScanPage.AccessibilityPageScan;
   performance: ScanPage.PerformancePageScan;
+  security: ScanPage.SecurityPageScan;
 };
 
 @Entity()
@@ -443,6 +445,21 @@ export class CoreResult {
   @Column({ nullable: true })
   @Expose({ name: 'language_link' })
   hrefLangContent?: string;
+
+  @Column({ nullable: true })
+  @Expose({ name: 'accessibility_scan_status' })
+  @Exclude()
+  securityScanStatus?: string;
+
+  @Column({ nullable: true })
+  @Expose({ name: 'https_enforced' })
+  @Exclude()
+  httpsEnforced?: boolean;
+
+  @Column({ nullable: true })
+  @Expose({ name: 'hsts_preloaded' })
+  @Exclude()
+  hstsPreloaded?: boolean;
 
   static getColumnNames(): string[] {
     // return class-transformer version of column names

--- a/entities/scan-data.entity.ts
+++ b/entities/scan-data.entity.ts
@@ -125,3 +125,8 @@ export type PerformanceScan = {
   largestContentfulPaint: number;
   cumulativeLayoutShift: number;
 };
+
+export type SecurityScan = {
+  httpsEnforced: boolean;
+  hstsPreloaded: boolean;
+};

--- a/entities/scan-page.entity.ts
+++ b/entities/scan-page.entity.ts
@@ -59,3 +59,9 @@ export type PerformanceScans = {
 };
 
 export type PerformancePageScan = PageScan<PerformanceScans>;
+
+export type SecurityScans = {
+  securityScan: ScanData.SecurityScan;
+};
+
+export type SecurityPageScan = PageScan<SecurityScans>;

--- a/libs/core-scanner/src/core-scanner.module.ts
+++ b/libs/core-scanner/src/core-scanner.module.ts
@@ -2,9 +2,10 @@ import { BrowserModule } from '@app/browser';
 import { Module } from '@nestjs/common';
 import { HttpModule } from '@nestjs/axios';
 import { CoreScannerService } from './core-scanner.service';
+import { SecurityDataModule } from '@app/security-data';
 
 @Module({
-  imports: [BrowserModule, HttpModule],
+  imports: [BrowserModule, HttpModule, SecurityDataModule],
   providers: [CoreScannerService],
   exports: [CoreScannerService],
 })

--- a/libs/core-scanner/src/core-scanner.service.ts
+++ b/libs/core-scanner/src/core-scanner.service.ts
@@ -32,12 +32,6 @@ export class CoreScannerService
     const scanLogger = this.logger.logger.child(input);
 
     return await this.browserService.useBrowser(async (browser) => {
-      const securityResult = await this.securityDataService.getSecurityResults(
-        input.url,
-      );
-
-      console.log(securityResult);
-
       const result = {
         base: {
           targetUrlBaseDomain: getBaseDomain(getHttpsUrl(input.url)),
@@ -53,6 +47,7 @@ export class CoreScannerService
           scanLogger,
         ),
         performance: await this.runPerformanceScan(browser, input, scanLogger),
+        security: await this.securityDataService.getSecurityResults(input.url),
       };
 
       scanLogger.info({ result }, 'solutions scan results');

--- a/libs/core-scanner/src/core-scanner.service.ts
+++ b/libs/core-scanner/src/core-scanner.service.ts
@@ -5,6 +5,7 @@ import { Logger } from 'pino';
 import { Browser } from 'puppeteer';
 
 import { BrowserService } from '@app/browser';
+import { SecurityDataService } from '@app/security-data';
 
 import { parseBrowserError, ScanStatus } from 'entities/scan-status';
 import { Scanner } from 'libs/scanner.interface';
@@ -22,6 +23,7 @@ export class CoreScannerService
   constructor(
     private browserService: BrowserService,
     private httpService: HttpService,
+    private securityDataService: SecurityDataService,
     @InjectPinoLogger(CoreScannerService.name)
     private readonly logger: PinoLogger,
   ) {}
@@ -30,6 +32,12 @@ export class CoreScannerService
     const scanLogger = this.logger.logger.child(input);
 
     return await this.browserService.useBrowser(async (browser) => {
+      const securityResult = await this.securityDataService.getSecurityResults(
+        input.url,
+      );
+
+      console.log(securityResult);
+
       const result = {
         base: {
           targetUrlBaseDomain: getBaseDomain(getHttpsUrl(input.url)),

--- a/libs/database/src/core-results/core-result.service.spec.ts
+++ b/libs/database/src/core-results/core-result.service.spec.ts
@@ -220,6 +220,15 @@ describe('CoreResultService', () => {
           },
         },
       },
+      security: {
+        status: scanStatus,
+        result: {
+          securityScan: {
+            httpsEnforced: null,
+            hstsPreloaded: null,
+          },
+        },
+      },
     };
     const logger = mock<Logger>();
 

--- a/libs/database/src/core-results/core-result.service.ts
+++ b/libs/database/src/core-results/core-result.service.ts
@@ -37,6 +37,7 @@ export class CoreResultService {
     this.updateDnsScanResults(coreResult, pages, logger);
     this.updateAccessibilityScanResults(coreResult, pages, logger);
     this.updatePerformanceScanResults(coreResult, pages, logger);
+    this.updateSecurityScanResults(coreResult, pages, logger);
 
     return this.create(coreResult);
   }
@@ -358,6 +359,29 @@ export class CoreResultService {
 
       coreResult.largestContentfulPaint = null;
       coreResult.cumulativeLayoutShift = null;
+    }
+  }
+
+  private updateSecurityScanResults(
+    coreResult: CoreResult,
+    pages: CoreResultPages,
+    logger: Logger,
+  ) {
+    coreResult.securityScanStatus = pages.security.status;
+
+    if (pages.security.status === ScanStatus.Completed) {
+      coreResult.httpsEnforced =
+        pages.security.result.securityScan.httpsEnforced;
+      coreResult.hstsPreloaded =
+        pages.security.result.securityScan.hstsPreloaded;
+    } else {
+      logger.error({
+        msg: pages.security.error,
+        page: 'security',
+      });
+
+      coreResult.httpsEnforced = null;
+      coreResult.hstsPreloaded = null;
     }
   }
 }

--- a/libs/security-data/src/config/security-data.config.ts
+++ b/libs/security-data/src/config/security-data.config.ts
@@ -1,0 +1,9 @@
+import { join } from 'path';
+
+export default () => {
+  return {
+    dirPath: join(process.cwd(), 'security-data'),
+    securityDataCsvUrl:
+      'https://raw.githubusercontent.com/GSA/federal-website-index/main/data/dataset/cisa_https.csv',
+  };
+};

--- a/libs/security-data/src/data-fetcher.ts
+++ b/libs/security-data/src/data-fetcher.ts
@@ -1,0 +1,15 @@
+import { Logger } from '@nestjs/common';
+
+export async function fetchSecurityData(url: string, logger: Logger) {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`${response.statusText}`);
+    }
+    return await response.text();
+  } catch (error) {
+    const err = error as Error;
+    logger.error(`An error occurred fetching security data: ${err.message}`);
+    return null;
+  }
+}

--- a/libs/security-data/src/index.ts
+++ b/libs/security-data/src/index.ts
@@ -1,0 +1,2 @@
+export * from './security-data.module';
+export * from './security-data.service';

--- a/libs/security-data/src/security-data.module.ts
+++ b/libs/security-data/src/security-data.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { SecurityDataService } from './security-data.service';
+import securityDataConfig from './config/security-data.config';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      load: [securityDataConfig],
+    }),
+  ],
+  providers: [SecurityDataService],
+  exports: [SecurityDataService],
+})
+export class SecurityDataModule {}

--- a/libs/security-data/src/security-data.service.ts
+++ b/libs/security-data/src/security-data.service.ts
@@ -1,0 +1,90 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { promises as fs } from 'fs';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { parseString } from 'fast-csv';
+import { fetchSecurityData } from './data-fetcher';
+
+type SecurityScanResult = {
+  httpsEnforced: boolean;
+  hstsPreloaded: boolean;
+};
+
+@Injectable()
+export class SecurityDataService {
+  private securityDataCsvUrl: string;
+  private dirPath: string;
+  private filePath: string;
+  private logger = new Logger(SecurityDataService.name);
+
+  constructor(private configService: ConfigService) {
+    this.securityDataCsvUrl =
+      this.configService.get<string>('securityDataCsvUrl');
+    this.dirPath = this.configService.get<string>('dirPath');
+    this.filePath = join(this.dirPath, 'security-data.csv');
+  }
+
+  async getSecurityResults(url: string): Promise<SecurityScanResult | null> {
+    this.logger.log(`Getting security results for ${url}`);
+
+    if (!existsSync(this.filePath)) {
+      this.logger.log(
+        `No file found for path ${this.filePath} -- fetching data`,
+      );
+      await this.fetchAndSaveSecurityData();
+    }
+
+    const csvString = await fs.readFile(this.filePath, 'utf8');
+
+    let matchingRow: { [key: string]: string } | null = null;
+
+    await new Promise((resolve, reject) => {
+      parseString(csvString, { headers: true })
+        .on('data', (row: { [key: string]: string }) => {
+          if (row.domain === url) {
+            matchingRow = row;
+            resolve(null);
+          }
+        })
+        .on('end', resolve)
+        .on('error', reject);
+    });
+
+    if (!matchingRow) {
+      this.logger.log('No matching domain found in CSV');
+      return null;
+    }
+
+    const httpsEnforced =
+      matchingRow.domain_enforces_https.toLowerCase() === 'true';
+    const hstsPreloaded =
+      matchingRow.hsts_base_domain_preloaded.toLowerCase() === 'true';
+
+    this.logger.log(
+      `Security results for ${url}: httpsEnforced=${httpsEnforced}, hstsPreloaded=${hstsPreloaded}`,
+    );
+
+    return {
+      httpsEnforced,
+      hstsPreloaded,
+    };
+  }
+
+  async fetchAndSaveSecurityData(): Promise<void> {
+    this.logger.log(`Fetching security data from ${this.securityDataCsvUrl}`);
+
+    const csvData = await fetchSecurityData(
+      this.securityDataCsvUrl,
+      this.logger,
+    );
+
+    if (csvData) {
+      await fs.mkdir(this.dirPath, { recursive: true });
+      await fs.writeFile(this.filePath, csvData, 'utf8');
+      this.logger.log(`Security data saved to ${this.filePath}`);
+    } else {
+      this.logger.error('No CSV data was fetched');
+    }
+  }
+}

--- a/libs/security-data/tsconfig.lib.json
+++ b/libs/security-data/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "../../dist/libs/security-data"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -144,7 +144,9 @@
       "@app/datetime/(.*)": "<rootDir>/libs/datetime/src/$1",
       "@app/datetime": "<rootDir>/libs/datetime/src",
       "@app/queue": "<rootDir>/libs/queue/src",
-      "@app/queue/(.*)": "<rootDir>/libs/queue/src/$1"
+      "@app/queue/(.*)": "<rootDir>/libs/queue/src/$1",
+      "@app/security-data/(.*)": "<rootDir>/libs/security-data/src/$1",
+      "@app/security-data": "<rootDir>/libs/security-data/src"
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,9 @@
       "@app/snapshot": ["libs/snapshot/src"],
       "@app/snapshot/*": ["libs/snapshot/src/*"],
       "@app/storage": ["libs/storage/src"],
-      "@app/storage/*": ["libs/storage/src/*"]
+      "@app/storage/*": ["libs/storage/src/*"],
+      "@app/security-data": ["libs/security-data/src"],
+      "@app/security-data/*": ["libs/security-data/src/*"]
     }
   }
 }


### PR DESCRIPTION
- Create a `security-data` library to:
  - Handle ingestion of security data CSV file
  - Provide access point for scanner to use in order to retrieve security results
- Incorporate security data points into `core-scanner` lib's service's main routine
- Add CLI command that we can hook into via GitHub Actions to reingest the security data CSV file on a regular basis