### PR TITLE
Update sitemap xml detected logic

### DIFF
--- a/libs/core-scanner/src/pages/sitemap-xml.ts
+++ b/libs/core-scanner/src/pages/sitemap-xml.ts
@@ -42,7 +42,7 @@ const buildSitemapResult = async (
   const sitemapLive = isLive(sitemapResponse);
 
   const sitemapXmlDetected =
-    sitemapUrl.pathname === '/sitemap.xml' && sitemapLive;
+    sitemapUrl.pathname.endsWith('/sitemap.xml') && sitemapLive;
 
   return {
     sitemapXmlFinalUrl: sitemapUrl.toString(),


### PR DESCRIPTION
Per item number 2 in https://github.com/GSA/site-scanning/issues/918, change the sitemap detected logic to make sure `/sitemap.xml` is at the end of the URL's path, not the entire path.