### PR TITLE
Required Links Scan Refactor

### DIFF
--- a/libs/core-scanner/src/pages/primary.ts
+++ b/libs/core-scanner/src/pages/primary.ts
@@ -62,7 +62,7 @@ const primaryScan = async (
     createUswdsScanner({ logger, getCSSRequests }, page)(response),
     buildLoginResult(response),
     buildCmsResult(response),
-    buildRequiredLinksResult(response),
+    buildRequiredLinksResult(page),
     buildSearchResult(page),
     buildMobileResult(logger, page),
   ]);

--- a/libs/core-scanner/src/scans/required-links.spec.ts
+++ b/libs/core-scanner/src/scans/required-links.spec.ts
@@ -1,84 +1,20 @@
-import { mock } from 'jest-mock-extended';
-import { HTTPResponse } from 'puppeteer';
-
+import { browserInstance, newTestPage } from '../test-helper';
 import { buildRequiredLinksResult } from './required-links';
 
 describe('required links scan', () => {
-  it('Detects if the response body has no required links', async () => {
-    const mockResonse = mock<HTTPResponse>({
-      text: async () => {
-        return '<html></html>';
-      },
-    });
-
-    expect(await buildRequiredLinksResult(mockResonse)).toEqual({
-      requiredLinksUrl: '',
-      requiredLinksText: '',
+  it('detects required links strings in href attribute and a element text', async () => {
+    await newTestPage(async ({ page }) => {
+      expect(await buildRequiredLinksResult(page)).toEqual({
+        requiredLinksUrl: 'about,foia,usa.gov',
+        requiredLinksText:
+          'accessibility,budget and performance,no fear act,foia,freedom of information act,inspector general,vulnerability disclosure,usa.gov',
+      });
     });
   });
 
-  it('Detects if the response has multiple required links', async () => {
-    const mockResonse = mock<HTTPResponse>({
-      text: async () => {
-        return `<html>
-            <a href="https://www.usa.gov">USA Dot Gov</a>
-            <a href="https://18f.gsa.gov/about/">About 18F</a>
-            <a href="https://www.gsa.gov/website-information/accessibility-statement">Accessibility Support</a>
-            <a href="https://www.foia.gov">Freedom of Information Act</a>
-            <a href="https://home.treasury.gov/footer/no-fear-act">No Fear Act</a>
-            <a href="https://www.gsaig.gov/">Office of the Inspector General</a>
-            <a href="https://www.gsa.gov/website-information/website-policies#privacy">Privacy Policy</a>
-            <a href="https://www.gsa.gov/vulnerability-disclosure-policy">Vulnerability Disclosure</a>
-            </html>`;
-      },
-    });
-
-    expect(await buildRequiredLinksResult(mockResonse)).toEqual({
-      requiredLinksUrl: 'about,fear,foia,privacy,usa.gov',
-      requiredLinksText:
-        'accessibility,no fear act,freedom of information act,inspector general,privacy policy,vulnerability disclosure',
-    });
-  });
-
-  it('Detects if the response has a usa.gov link', async () => {
-    const mockResonse = mock<HTTPResponse>({
-      text: async () => {
-        return '<html><a href="https://www.usa.gov">USA Dot Gov</a></html>';
-      },
-    });
-
-    expect(await buildRequiredLinksResult(mockResonse)).toEqual({
-      requiredLinksUrl: 'usa.gov',
-      requiredLinksText: '',
-    });
-  });
-
-  it('Detects if the response has a foia link', async () => {
-    const mockResonse = mock<HTTPResponse>({
-      text: async () => {
-        return '<html><a href="https://www.foia.gov">Freedom of Information Act</a></html>';
-      },
-    });
-
-    expect(await buildRequiredLinksResult(mockResonse)).toEqual({
-      requiredLinksUrl: 'foia',
-      requiredLinksText: 'freedom of information act',
-    });
-  });
-
-  it('Detects if the response has a both a usa.gov link and a foia link', async () => {
-    const mockResonse = mock<HTTPResponse>({
-      text: async () => {
-        return `<html>
-            <a href="https://www.usa.gov">USA Dot Gov</a>
-            <a href="https://www.foia.gov">Freedom of Information Act</a>
-            </html>`;
-      },
-    });
-
-    expect(await buildRequiredLinksResult(mockResonse)).toEqual({
-      requiredLinksUrl: 'foia,usa.gov',
-      requiredLinksText: 'freedom of information act',
-    });
+  afterAll(async () => {
+    if (browserInstance) {
+      await browserInstance.close();
+    }
   });
 });

--- a/libs/core-scanner/src/scans/required-links.ts
+++ b/libs/core-scanner/src/scans/required-links.ts
@@ -1,70 +1,75 @@
-import { HTTPResponse } from 'puppeteer';
+import { Page } from 'puppeteer';
 
 import { RequiredLinksScan } from 'entities/scan-data.entity';
 
 export const buildRequiredLinksResult = async (
-  mainResponse: HTTPResponse,
+  page: Page,
 ): Promise<RequiredLinksScan> => {
-  const html = await mainResponse.text();
+  const requiredLinksResults = await page.evaluate(() => {
+    const requiredLinksUrlContents = [
+      'about',
+      'fear',
+      'foia',
+      'inspector',
+      'privacy',
+      'usa.gov',
+      'spanish',
+      'espanol',
+      'español',
+      '/es',
+    ];
 
-  const requiredLinksUrl = [
-    'about',
-    'fear',
-    'foia',
-    'inspector',
-    'privacy',
-    'usa.gov',
-    'spanish',
-    'espanol',
-    'español',
-    '/es',
-  ]
-    .filter((string) => hasStringInHref(html, string))
-    .join(',');
+    const requiredLinksUrl = requiredLinksUrlContents
+      .filter((string) => {
+        let stringDetected = false;
 
-  const requiredLinksText = [
-    'about us',
-    'accessibility',
-    'budget and performance',
-    'no fear act',
-    'foia',
-    'freedom of information act',
-    'inspector general',
-    'privacy policy',
-    'vulnerability disclosure',
-    'usa.gov',
-    'espanol',
-    'español',
-    'espa&ntilde;ol',
-    'spanish',
-  ]
-    .filter((string) => hasStringInLinkText(html, string))
-    .join(',');
+        document.querySelectorAll('a').forEach((el) => {
+          const href = el.getAttribute('href');
+          if (href && href.toLowerCase().includes(string)) {
+            stringDetected = true;
+          }
+        });
 
-  return {
-    requiredLinksUrl,
-    requiredLinksText,
-  };
-};
+        return stringDetected;
+      })
+      .join(',');
 
-const hasStringInHref = (html: string, string: string): boolean => {
-  const hrefs = html.match(/href=['"](.*?)['"]/gi);
+    const requiredLinksTextContents = [
+      'about us',
+      'accessibility',
+      'budget and performance',
+      'no fear act',
+      'foia',
+      'freedom of information act',
+      'inspector general',
+      'privacy policy',
+      'vulnerability disclosure',
+      'usa.gov',
+      'espanol',
+      'español',
+      'espa&ntilde;ol',
+      'spanish',
+    ];
 
-  if (!hrefs) return false;
-  const matchingHrefs = hrefs.filter((href) =>
-    href.toLowerCase().includes(string.toLowerCase()),
-  );
+    const requiredLinksText = requiredLinksTextContents
+      .filter((string) => {
+        let stringDetected = false;
 
-  return matchingHrefs.length > 0;
-};
+        document.querySelectorAll('a').forEach((el) => {
+          if (el.textContent.toLowerCase().includes(string)) {
+            stringDetected = true;
+          }
+        });
 
-const hasStringInLinkText = (html: string, string: string): boolean => {
-  const linkTexts = html.match(/(?<=<a\b[^>]*>)([\s\S]*?)(?=<\/a>)/gi);
+        return stringDetected;
+      })
+      .join(',');
 
-  if (!linkTexts) return false;
-  const matchingLinkTexts = linkTexts.filter((linkText) =>
-    linkText.toLowerCase().includes(string.toLowerCase()),
-  );
+    return {
+      requiredLinksUrl,
+      requiredLinksText,
+    };
+  });
 
-  return matchingLinkTexts.length > 0;
+  return requiredLinksResults;
 };


### PR DESCRIPTION
Refactor required links scan to use puppeteer page instead of regex.