### PR TITLE
Add Enqueue-Site CLI Command and GitHub Actions Workflow

### DIFF
--- a/.github/workflows/enqueue-site.yml
+++ b/.github/workflows/enqueue-site.yml
@@ -1,0 +1,33 @@
+---
+name: Enqueue site
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+    inputs:
+      cf_space:
+        description: deployed cloud.gov space
+        required: true
+        default: prod
+      scan_url:
+        description: url to be queued
+        required: true
+        type: string
+
+jobs:
+  enqueue:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: run enqueue-site cli job in chosen space
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          cf_api: https://api.fr.cloud.gov
+          cf_username: ${{ secrets.CF_USERNAME }}
+          cf_password: ${{ secrets.CF_PASSWORD }}
+          cf_org: gsatts-sitescan
+          cf_space: ${{ github.event.inputs.cf_space || 'prod' }}
+          cf_command: run-task site-scanner-consumer
+            -c "node dist/apps/cli/main.js enqueue-site --url ${{ github.event.inputs.scan_url }}"
+            -k 2G -m 2G
+            --name github-action-enqueue-site-${{ github.run_id }}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -88,6 +88,17 @@ async function checkQueueStatus() {
   await nestApp.close();
 }
 
+async function enqueueSite(cmdObj) {
+  const nestApp = await bootstrap();
+  const logger = createCommandLogger('enqueue-site', { url: cmdObj.url });
+  const controller = nestApp.get(QueueController);
+  logger.info('enqueueing specific url');
+
+  await controller.queueSite(cmdObj.url);
+  printMemoryUsage(logger);
+  await nestApp.close();
+}
+
 async function enqueueLimitedScans(cmdObj) {
   const nestApp = await bootstrap();
   const logger = createCommandLogger('enqueue-limited-scans', { limit: cmdObj.limit });
@@ -192,6 +203,18 @@ async function main() {
       'enqueue-scans adds each target in the Website database table to the redis queue',
     )
     .action(enqueueScans);
+
+  // queue-site
+  program
+    .command('enqueue-site')
+    .description(
+      'enqueue-site add 1 site from the Website database table to the redis queue',
+    )
+    .option(
+      '--url <string>',
+      'queue up one specific site by URL'
+    )
+    .action(enqueueSite);
 
   // queue-status
   program

--- a/apps/cli/src/queue.controller.ts
+++ b/apps/cli/src/queue.controller.ts
@@ -43,6 +43,27 @@ export class QueueController {
     }
   }
 
+  async queueSite(url: string) {
+    this.logger.log(`queueing site: ${url}`);
+
+    try {
+      let website = await this.websiteService.findByUrl(url);
+
+      const coreInput: CoreInputDto = {
+        websiteId: website.id,
+        url: website.url,
+        scanId: cuid(),
+      };
+      await this.queueService.addCoreJob(coreInput);
+
+      const queueStatus = await this.queueService.getQueueStatus();
+      this.logger.log({ msg: 'successfully added to queue', queueStatus });
+    } catch (error) {
+      const err = error as Error;
+      this.logger.error(err.message, err.stack);
+    }
+  }
+
   async clearQueue() {
     this.logger.log('starting to clear queue...');
 


### PR DESCRIPTION
## Purpose
Introduce a new `enqueue-site` CLI command for enqueuing a specific site to the scan queue. Additionally, a new GitHub Actions workflow has been added, enabling users to specify a URL for queuing in the scan process.