### PR TITLE
Improve Page Load Handling and Logging: Update waitUntil, Add Redirect/Failure Metadata

### DIFF
--- a/libs/core-scanner/src/core-scanner.service.ts
+++ b/libs/core-scanner/src/core-scanner.service.ts
@@ -68,6 +68,11 @@ export class CoreScannerService
       scanUrl: input.url,
       sseUrl: input.url,
       websiteId: input.websiteId,
+      job: {
+        data: {
+          scanId: input.scanId,
+        }
+      }
     });
   }
 

--- a/libs/core-scanner/src/pages/primary.ts
+++ b/libs/core-scanner/src/pages/primary.ts
@@ -43,7 +43,7 @@ const primaryScan = async (
   const getCSSRequests = await createCSSRequestsExtractor(page, pageLogger);
   const getOutboundRequests = createOutboundRequestsExtractor(page);
 
-  const response = await page.goto(url, { waitUntil: 'domcontentloaded' });
+  const response = await page.goto(url, { waitUntil: 'networkidle2' });
   const chain = response.request().redirectChain();
   pageLogger.info({ sseRedirectChain: chain, sseResponseStatus: response.status }, `${url} returned status code ${response.status()}`);
 

--- a/libs/core-scanner/src/pages/primary.ts
+++ b/libs/core-scanner/src/pages/primary.ts
@@ -44,7 +44,8 @@ const primaryScan = async (
   const getOutboundRequests = createOutboundRequestsExtractor(page);
 
   const response = await page.goto(url, { waitUntil: 'domcontentloaded' });
-  pageLogger.info({ sseResponseStatus: response.status }, `${url} returned status code ${response.status()}`);
+  const chain = response.request().redirectChain();
+  pageLogger.info({ sseRedirectChain: chain, sseResponseStatus: response.status }, `${url} returned status code ${response.status()}`);
 
   const wrappedDapResult = runScan(input, pageLogger, buildDapResult, 'DAPScan', url);
   const wrappedThirdPartyResult = runScan(input, pageLogger, buildThirdPartyResult, 'ThirdPartyScan', url);

--- a/libs/core-scanner/src/util.ts
+++ b/libs/core-scanner/src/util.ts
@@ -76,6 +76,6 @@ export function getTruncatedUrl(url: string): string {
 export function createRequestHandlers(page: Page, logger: Logger) {
   page.on('console', (message) => logger.debug({sseMessage: message }, `Page Log: ${message.text()}`));
   page.on('error', (error) => logger.warn({ error }, `Page Error: ${error.message}`));
-  page.on('response', (response)=> response.status() !== 200 && logger.debug({ sseResponseUrl: response.url(), sseResponseStatus: response.status()}, `A ${response.status()} was returned from: ${getTruncatedUrl(response.url())} `));
-  page.on('requestfailed', (request) => logger.warn({ sseRequestUrl: request.url() }, `Request failed: ${getTruncatedUrl(request.url())}`));
+  page.on('response', (response)=> response.status() !== 200 && logger.debug({ sseResponseTiming: response.timing(), sseResponseUrl: response.url(), sseResponseStatus: response.status()}, `A ${response.status()} was returned from: ${getTruncatedUrl(response.url())} `));
+  page.on('requestfailed', (request) => logger.warn({ sseRequestFailure: request.failure(), sseRequestUrl: request.url() }, `Request failed due to ${request.failure().errorText} for ${getTruncatedUrl(request.url())}`));
 };


### PR DESCRIPTION
## Purpose
This pull request enhances page load handling and logging capabilities. The key changes include:

- Switching waitUntil to networkidle2 for more reliable page load detection.
- Adding metadata to log redirect chains and failure reasons for better traceability.
- Passing job metadata to page scans for improved context in log entries.

These updates aim to improve the accuracy and clarity of page load events and related diagnostics.