### PR TITLE
Update requestfailed meta to prevent undefined error.

### DIFF
--- a/libs/core-scanner/src/util.ts
+++ b/libs/core-scanner/src/util.ts
@@ -77,5 +77,5 @@ export function createRequestHandlers(page: Page, logger: Logger) {
   page.on('console', (message) => logger.debug({sseMessage: message }, `Page Log: ${message.text()}`));
   page.on('error', (error) => logger.warn({ error }, `Page Error: ${error.message}`));
   page.on('response', (response)=> response.status() !== 200 && logger.debug({ sseResponseTiming: response.timing(), sseResponseUrl: response.url(), sseResponseStatus: response.status()}, `A ${response.status()} was returned from: ${getTruncatedUrl(response.url())} `));
-  page.on('requestfailed', (request) => logger.warn({ sseRequestFailure: request.failure(), sseRequestUrl: request.url() }, `Request failed due to ${request.failure().errorText} for ${getTruncatedUrl(request.url())}`));
+  page.on('requestfailed', (request) => logger.warn({ sseRequestFailure: request.failure(), sseRequestUrl: request.url() }, `Request failed for ${getTruncatedUrl(request.url())}`));
 };


### PR DESCRIPTION
## Purpose
This change eliminates the usage of errorText from request.failure() which was causing an undefined error in certain cases. This ensures more stable error handling and prevents runtime issues related to undefined values.