### PR TITLE
Use mock for internal GSA DNS lookup

### DIFF
--- a/libs/core-scanner/src/pages/dns.spec.ts
+++ b/libs/core-scanner/src/pages/dns.spec.ts
@@ -5,12 +5,15 @@ import * as dns from './dns';
 
 describe('dns scan', () => {
   it('integrates with node.js dns module', async () => {
+    // See the jest setup. This first test uses a mock DNS resolution because gsa.gov has no AAAA
+    // record if using internal DNS (i.e. while on VPN).
     const result = await dns.dnsScan(mock<Logger>(), 'gsa.gov');
     expect(result.ipv6).toEqual(true);
     expect(result.dnsHostname).toEqual('amazonaws.com');
   });
 
   it('catches an error when the scanned site has no IPv6 record available', async () => {
+    // This test isn't subject to the VPN issue so it hits the network.
     const result = await dns.dnsScan(mock<Logger>(), 'github.com');
     expect(result.ipv6).toEqual(false);
     expect(result.dnsHostname).toEqual('github.com');

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -26,6 +26,7 @@ jest.mock('dns', () => {
   return {
     ...actualDns,
     promises: {
+      ...actualDns.promises,
       resolve6: jest.fn((hostname: string) => {
         if (hostname === 'gsa.gov') {
           return Promise.resolve(['2001:0db8:85a3:0000:0000:8a2e:0370:7334']);
@@ -37,18 +38,6 @@ jest.mock('dns', () => {
           return Promise.resolve(['d2u8q06xshnec9.cloudfront.net.amazonaws.com']);
         }
         return actualDns.promises.resolveCname(hostname);
-      }),
-      resolve: jest.fn((hostname: string) => {
-        if (hostname === 'gsa.gov') {
-          return Promise.resolve(['13.249.70.113']);
-        }
-        return actualDns.promises.resolve(hostname);
-      }),
-      reverse: jest.fn((ip: string) => {
-        if (ip === '13.249.70.113') {
-          return Promise.resolve(['server-13-249-70-113.iad89.r.cloudfront.net']);
-        }
-        return actualDns.promises.reverse(ip);
       }),
     },
   };

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -20,3 +20,36 @@ jest.mock('pino', () => {
   mockPino.default = mockPino; // Ensure that the default export is the mock
   return mockPino;
 });
+
+jest.mock('dns', () => {
+  const actualDns = jest.requireActual('dns');
+  return {
+    ...actualDns,
+    promises: {
+      resolve6: jest.fn((hostname: string) => {
+        if (hostname === 'gsa.gov') {
+          return Promise.resolve(['2001:0db8:85a3:0000:0000:8a2e:0370:7334']);
+        }
+        return actualDns.promises.resolve6(hostname);
+      }),
+      resolveCname: jest.fn((hostname: string) => {
+        if (hostname === 'gsa.gov') {
+          return Promise.resolve(['d2u8q06xshnec9.cloudfront.net.amazonaws.com']);
+        }
+        return actualDns.promises.resolveCname(hostname);
+      }),
+      resolve: jest.fn((hostname: string) => {
+        if (hostname === 'gsa.gov') {
+          return Promise.resolve(['13.249.70.113']);
+        }
+        return actualDns.promises.resolve(hostname);
+      }),
+      reverse: jest.fn((ip: string) => {
+        if (ip === '13.249.70.113') {
+          return Promise.resolve(['server-13-249-70-113.iad89.r.cloudfront.net']);
+        }
+        return actualDns.promises.reverse(ip);
+      }),
+    },
+  };
+});


### PR DESCRIPTION
GSA's internal DNS does not have a AAAA record configured if on zScaler causing one of the tests to fail if on the internal network. This uses a mock for the internal DNS test so it works inside or outside the GSA's internal network.

Closes: https://github.com/GSA/site-scanning/issues/1875