### PR TITLE
Fix acessibility snapshot name

### DIFF
--- a/libs/snapshot/src/snapshot.service.spec.ts
+++ b/libs/snapshot/src/snapshot.service.spec.ts
@@ -51,6 +51,9 @@ describe('SnapshotService', () => {
               if (key === 'fileNameDailyAll') {
                 return 'site-scanning-latest';
               }
+              if (key === 'fileNameAccessibility') {
+                return 'weekly-snapshot-accessibility-details';
+              }
             }),
           },
         },
@@ -194,5 +197,50 @@ describe('SnapshotService', () => {
     expect(mockStorageService.upload.mock.calls).toEqual(
       expect.arrayContaining(expectedUploadCalls),
     );
+  });
+
+  it('should archive the previous a11y snapshot with a date-only key and upload the new one', async () => {
+    const coreResult = new CoreResult();
+    coreResult.accessibilityResultsList = JSON.stringify([
+      { id: 'color-contrast', impact: 'serious' },
+    ]);
+
+    const website = new Website();
+    website.coreResult = coreResult;
+    website.url = 'supremecourt.gov';
+
+    mockWebsiteService.findAccessibilityResultsSnapshotResults.mockResolvedValue(
+      [website],
+    );
+
+    const fixedDate = new Date('2026-02-20T00:00:00.000Z');
+    mockDatetimeService.now.mockReturnValue(new Date(fixedDate));
+
+    // priorDate should be 7 days before fixedDate
+    const expectedPriorDate = '2026-02-13';
+
+    await service.accessibilityResultsSnapshot();
+
+    // archive copy must use date-only string (YYYY-MM-DD), not a full ISO timestamp
+    expect(mockStorageService.copy).toHaveBeenCalledWith(
+      'weekly-snapshot-accessibility-details.json',
+      `archive/json/weekly-snapshot-accessibility-details-${expectedPriorDate}.json`,
+    );
+
+    // new snapshot must be uploaded
+    expect(mockStorageService.upload).toHaveBeenCalledWith(
+      'weekly-snapshot-accessibility-details.json',
+      expect.any(String),
+    );
+
+    // uploaded content must be valid JSON with expected shape
+    const uploadedContent = mockStorageService.upload.mock.calls[0][1] as string;
+    const parsed = JSON.parse(uploadedContent);
+    expect(parsed).toEqual([
+      {
+        target_url: 'supremecourt.gov',
+        accessibility_details: [{ id: 'color-contrast', impact: 'serious' }],
+      },
+    ]);
   });
 });

--- a/libs/snapshot/src/snapshot.service.ts
+++ b/libs/snapshot/src/snapshot.service.ts
@@ -179,9 +179,9 @@ export class SnapshotService {
     this.logger.log('Backing up previous snapshot');
     const date = this.datetimeService.now();
     date.setDate(date.getDate() - 7);
-    const priorDate = date.toISOString();
+    const priorDate = date.toISOString().split('T')[0];
     const newFileName = `archive/json/${this.fileNameAccessibility}-${priorDate}.json`;
-    this.storageService.copy(`${this.fileNameAccessibility}.json`, newFileName);
+    await this.storageService.copy(`${this.fileNameAccessibility}.json`, newFileName);
 
     this.logger.log('Serializing new snapshot');
     const serializedWebsitesWithDetailsOnly = websites.map((website) => {


### PR DESCRIPTION
## Summary

Accessibility detail snapshots stopped appearing at their expected S3 URLs (e.g. weekly-snapshot-accessibility-details-2025-12-17.json). The cause was due to a timestamp handling issue in the accessibility snapshot function. Instead of being saved as `YYYY-MM-DD`, they were being saved with a full timestamp, e.g. `weekly-snapshot-accessibility-details-2026-06-16T13:24:51.323Z.json`.

Additionally, there was an issue with the archive copy running concurrently with the subsequent upload to the same key due to a missing `await`. In practice this created a race condition where the current file could be overwritten before the archive copy completed. Both issues were corrected in this PR

References: https://github.com/GSA/site-scanning/issues/1906

## Notes

Daily accessibility snapshot files should now be discoverable at their expected URLs going forward. Previously published files under the garbled names will remain in S3 but were not cleaned up as part of this change. These files cover snapshots beginning June 3, 2025 and running through June 16, 2026 (or whenever this is merged and deployed).
