### PR TITLE
Fix stale scan_date for retryable errors that exhaust retries (failure mode 2)

### DIFF
--- a/apps/scan-engine/src/scan-engine.consumer.spec.ts
+++ b/apps/scan-engine/src/scan-engine.consumer.spec.ts
@@ -139,8 +139,7 @@ describe('ScanEngineConsumer', () => {
 
   describe('onFailed', () => {
     // Helper to build a minimal mock Job for the onFailed handler.
-    // Bull's `attemptsMade` reflects how many attempts have been made so far
-    // (1-indexed: after first attempt it is 1, after third it is 3).
+    // `attemptsMade` reflects how many attempts have been made so far.
     function makeFailedJob(
       input: CoreInputDto,
       attemptsMade: number,

--- a/apps/scan-engine/src/scan-engine.consumer.spec.ts
+++ b/apps/scan-engine/src/scan-engine.consumer.spec.ts
@@ -136,4 +136,80 @@ describe('ScanEngineConsumer', () => {
     expect(mockCoreResultService.writeFailedResult).not.toHaveBeenCalled();
     expect(mockCoreResultService.createFromCoreResultPages).not.toHaveBeenCalled();
   });
+
+  describe('onFailed', () => {
+    // Helper to build a minimal mock Job for the onFailed handler.
+    // Bull's `attemptsMade` reflects how many attempts have been made so far
+    // (1-indexed: after first attempt it is 1, after third it is 3).
+    function makeFailedJob(
+      input: CoreInputDto,
+      attemptsMade: number,
+      attempts: number,
+    ): Job<CoreInputDto> {
+      return {
+        id: 'test-job-id',
+        data: input,
+        attemptsMade,
+        opts: { attempts },
+      } as unknown as Job<CoreInputDto>;
+    }
+
+    it('should write a failure result when retries are exhausted (final attempt)', async () => {
+      const input = defaultInput;
+      const job = makeFailedJob(input, 3, 3);
+      const timeoutError = new Error('net::ERR_TIMED_OUT');
+
+      await consumer.onFailed(job, timeoutError);
+
+      expect(mockCoreResultService.writeFailedResult).toHaveBeenCalledWith(
+        input.websiteId,
+        ScanStatus.Timeout,
+        expect.anything(),
+        input.filter,
+        input.pageviews,
+        input.visits,
+        input.url,
+      );
+    });
+
+    it('should write an UnknownError result when the error does not match a known pattern', async () => {
+      const input = defaultInput;
+      const job = makeFailedJob(input, 3, 3);
+      const unknownError = new Error('some unexpected error message');
+
+      await consumer.onFailed(job, unknownError);
+
+      expect(mockCoreResultService.writeFailedResult).toHaveBeenCalledWith(
+        input.websiteId,
+        ScanStatus.UnknownError,
+        expect.anything(),
+        input.filter,
+        input.pageviews,
+        input.visits,
+        input.url,
+      );
+    });
+
+    it('should NOT write a failure result on an intermediate (non-final) attempt', async () => {
+      const input = defaultInput;
+      // attemptsMade=1, attempts=3 → two retries remain
+      const job = makeFailedJob(input, 1, 3);
+      const timeoutError = new Error('net::ERR_TIMED_OUT');
+
+      await consumer.onFailed(job, timeoutError);
+
+      expect(mockCoreResultService.writeFailedResult).not.toHaveBeenCalled();
+    });
+
+    it('should NOT write a failure result on a second intermediate attempt', async () => {
+      const input = defaultInput;
+      // attemptsMade=2, attempts=3 → one retry remains
+      const job = makeFailedJob(input, 2, 3);
+      const connectionResetError = new Error('net::ERR_CONNECTION_RESET');
+
+      await consumer.onFailed(job, connectionResetError);
+
+      expect(mockCoreResultService.writeFailedResult).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/scan-engine/src/scan-engine.consumer.ts
+++ b/apps/scan-engine/src/scan-engine.consumer.ts
@@ -4,6 +4,7 @@ import {
   OnQueueCompleted,
   OnQueueDrained,
   OnQueueError,
+  OnQueueFailed,
   OnQueueStalled,
   Process,
   Processor,
@@ -148,6 +149,64 @@ export class ScanEngineConsumer {
   onCompleted(job: Job<CoreInputDto>) {
     this.logger.log({
       msg: 'Processed job',
+      job,
+    });
+  }
+
+  /**
+   * onFailed handles the Bull `failed` event, which fires after every failed
+   * attempt (including intermediate retries).
+   *
+   * We only write a failure result once retries are exhausted
+   * (attemptsMade >= opts.attempts). On intermediate attempts we log and
+   * return so Bull can schedule the next retry normally.
+   *
+   * This covers failure mode 2 from GSA/site-scanning#1898: non-permanent
+   * errors (e.g. Timeout, ConnectionReset) exhaust their 3 retry attempts
+   * without any DB write, leaving the row stale. After the final attempt we
+   * classify the error via parseBrowserError and persist a failure result so
+   * the scan_date is updated and downstream consumers see an accurate status.
+   *
+   * Failure mode 1 (permanent errors) is handled inside processCore and
+   * returns without throwing, so those jobs never reach the failed set and
+   * this handler is not invoked for them.
+   */
+  @OnQueueFailed()
+  async onFailed(job: Job<CoreInputDto>, err: Error) {
+    const attempts = job.opts.attempts ?? 1;
+
+    if (job.attemptsMade < attempts) {
+      // Intermediate attempt — Bull will retry; nothing to persist yet.
+      this.logger.warn({
+        msg: `Job ${job.id} failed (attempt ${job.attemptsMade}/${attempts}), will retry`,
+        url: job.data.url,
+        error: err.message,
+      });
+      return;
+    }
+
+    // Final attempt exhausted — write a failure result so the row is updated.
+    this.logger.warn({
+      msg: `Job ${job.id} failed after all ${attempts} attempts, writing failure result`,
+      url: job.data.url,
+      error: err.message,
+    });
+
+    const failureStatus = parseBrowserError(err);
+
+    await this.coreResultService.writeFailedResult(
+      job.data.websiteId,
+      failureStatus,
+      this.logger,
+      job.data.filter,
+      job.data.pageviews,
+      job.data.visits,
+      job.data.url,
+    );
+
+    this.logger.log({
+      msg: `wrote failure result for ${job.data.url} after exhausted retries`,
+      status: failureStatus,
       job,
     });
   }

--- a/apps/scan-engine/src/scan-engine.consumer.ts
+++ b/apps/scan-engine/src/scan-engine.consumer.ts
@@ -154,21 +154,19 @@ export class ScanEngineConsumer {
   }
 
   /**
-   * onFailed handles the Bull `failed` event, which fires after every failed
+   * onFailed handles the `failed` event, which fires after every failed
    * attempt (including intermediate retries).
    *
    * We only write a failure result once retries are exhausted
    * (attemptsMade >= opts.attempts). On intermediate attempts we log and
-   * return so Bull can schedule the next retry normally.
+   * return so we can requeue and try again.
    *
-   * This covers failure mode 2 from GSA/site-scanning#1898: non-permanent
-   * errors (e.g. Timeout, ConnectionReset) exhaust their 3 retry attempts
-   * without any DB write, leaving the row stale. After the final attempt we
-   * classify the error via parseBrowserError and persist a failure result so
-   * the scan_date is updated and downstream consumers see an accurate status.
+   * This covers non-permanent errors (e.g. Timeout, ConnectionReset).
+   * After the final attempt we classify the error via parseBrowserError and
+   * persist a failure result so the scan_date is updated.
    *
-   * Failure mode 1 (permanent errors) is handled inside processCore and
-   * returns without throwing, so those jobs never reach the failed set and
+   * Permanent errors are handled inside processCore and
+   * return without throwing, so those jobs never reach the failed set, and
    * this handler is not invoked for them.
    */
   @OnQueueFailed()

--- a/libs/database/src/core-results/core-result.service.spec.ts
+++ b/libs/database/src/core-results/core-result.service.spec.ts
@@ -553,6 +553,9 @@ describe('CoreResultService', () => {
       websiteUrl,
     );
 
+    // update() is used (not save()) to avoid an extra internal SELECT.
+    // `updated` is set explicitly so @UpdateDateColumn is refreshed even
+    // though repository.update() bypasses TypeORM's lifecycle hooks.
     expect(mockRepository.update).toHaveBeenCalledWith(
       123,
       expect.objectContaining({
@@ -560,6 +563,7 @@ describe('CoreResultService', () => {
         notFoundScanStatus: failureStatus,
         finalUrl: null,
         pageTitle: null,
+        updated: expect.any(String),
       }),
     );
     expect(mockRepository.insert).not.toHaveBeenCalled();

--- a/libs/database/src/core-results/core-result.service.spec.ts
+++ b/libs/database/src/core-results/core-result.service.spec.ts
@@ -553,7 +553,6 @@ describe('CoreResultService', () => {
       websiteUrl,
     );
 
-    // update() is used (not save()) to avoid an extra internal SELECT.
     // `updated` is set explicitly so @UpdateDateColumn is refreshed even
     // though repository.update() bypasses TypeORM's lifecycle hooks.
     expect(mockRepository.update).toHaveBeenCalledWith(

--- a/libs/database/src/core-results/core-result.service.ts
+++ b/libs/database/src/core-results/core-result.service.ts
@@ -585,7 +585,15 @@ export class CoreResultService {
     });
 
     if (exists) {
-      await this.coreResultRepository.update(exists.id, coreResult);
+      // Explicitly set `updated` so TypeORM's @UpdateDateColumn is refreshed.
+      // repository.update() issues a raw SQL UPDATE that bypasses TypeORM's
+      // entity lifecycle hooks, leaving `updated` (= scan_date) stale for sites
+      // that already have a core_result row. Setting it here avoids the extra
+      // SELECT that repository.save() would otherwise perform internally.
+      await this.coreResultRepository.update(exists.id, {
+        ...coreResult,
+        updated: new Date().toISOString(),
+      });
     } else {
       await this.coreResultRepository.insert(coreResult);
     }

--- a/libs/queue/src/queue.service.ts
+++ b/libs/queue/src/queue.service.ts
@@ -32,6 +32,9 @@ export class QueueService {
         type: 'exponential',
         delay: 30000,
       },
+      // Keep failed jobs for debugging/forensics (job payload + stacktrace) even
+      // though we now persist a failure status/result to the DB on final retry
+      // exhaustion (see ScanEngineConsumer @OnQueueFailed handler).
       removeOnFail: false,
     });
     return job;


### PR DESCRIPTION
## Summary

Addresses failure mode 2 from GSA/site-scanning#1898.

Sites that encounter non-permanent errors (e.g. timeouts, connection resets) are retried up to 3 times by Bull. When all retries are exhausted, no DB write was occurring, leaving the `core_result` row and its public-facing `scan_date` field permanently stale.

## Changes

### `apps/scan-engine/src/scan-engine.consumer.ts`

Adds an `@OnQueueFailed()` handler (`onFailed`) that:
- On intermediate attempts: logs and returns, allowing Bull to schedule the next retry normally.
- On the final attempt (retries exhausted): classifies the error via `parseBrowserError` and calls `writeFailedResult` to persist a failure status and refresh `scan_date`.

Failure mode 1 (permanent errors: DNS, bad SSL) is handled inside `processCore` and returns without rethrowing, so those jobs never reach the Bull `failed` event and `onFailed` is not invoked for them.

### `libs/database/src/core-results/core-result.service.ts`

Fixes a pre-existing bug in `upsertCoreResult`: `repository.update()` issues a raw SQL `UPDATE` that bypasses TypeORM's entity lifecycle hooks, leaving `@UpdateDateColumn` (`updated` / `scan_date`) stale when a row already exists. Explicitly setting `updated: new Date().toISOString()` in the update payload ensures the timestamp is always refreshed without the extra internal `SELECT` that `repository.save()` would add.

### `libs/queue/src/queue.service.ts`

Keeps the existing `removeOnFail: false` behavior with a clarifying comment to document the strategy.

## Testing

- Added 4 unit tests for `onFailed` covering: final attempt writes failure result, unknown error maps to `UnknownError`, intermediate attempts do not write.
- Updated `CoreResultService` spec to assert `update()` is called with an explicit `updated` string on existing rows.
- Manual verification: enqueue `blackhole.webpagetest.org` and confirm `updated` differs from `created` in the `core_result` row after retries exhaust.