### PR TITLE
Add data freshness tracking for DAP and HTTPS source files

### DIFF
--- a/.github/workflows/update-data-freshness-dates.yml
+++ b/.github/workflows/update-data-freshness-dates.yml
@@ -1,0 +1,27 @@
+---
+name: Update data freshness dates
+
+# yamllint disable-line rule:truthy
+on:
+  schedule:
+    - cron: '30 22 * * 1,3,5'
+
+  workflow_dispatch:
+
+jobs:
+  data-freshness:
+    runs-on: ubuntu-latest
+    steps:
+      - name: run data-freshness cli job in chosen space
+        uses: cloud-gov/cg-cli-tools@bafcd2b3d36984482c01b1dd2c3750b4f355b8a2 # main
+        with:
+          cf_api: https://api.fr.cloud.gov
+          cf_username: ${{ secrets.CF_USERNAME }}
+          cf_password: ${{ secrets.CF_PASSWORD }}
+          cf_org: gsatts-sitescan
+          cf_space: prod
+          cf_command: |
+            run-task site-scanner-consumer
+            --command "node dist/apps/cli/main.js data-freshness"
+            -k 2G -m 2G
+            --name github-action-data-freshness-${{ github.run_id }}

--- a/apps/api/src/website/website-api-result.dto.ts
+++ b/apps/api/src/website/website-api-result.dto.ts
@@ -9,6 +9,24 @@ export class WebsiteApiResultDto {
   scan_date: string;
 
   /**
+   * `dap_data_date` is the date the DAP analytics source file was last updated
+   * in the federal-website-index repository. Reflects the freshness of the
+   * `pageviews` and `visits` fields.
+   *
+   * @example 2026-05-16
+   */
+  dap_data_date: string;
+
+  /**
+   * `https_data_date` is the date the CISA HTTPS source file was last updated
+   * in the federal-website-index repository. Reflects the freshness of the
+   * `https_enforced` and `hsts` fields.
+   *
+   * @example 2026-05-21
+   */
+  https_data_date: string;
+
+  /**
    * `target_url_domain` is the base domain (domain name + top-level domain) of the target url.
    *
    * @example 18f.gov

--- a/apps/cli/src/app.module.ts
+++ b/apps/cli/src/app.module.ts
@@ -12,6 +12,7 @@ import { QueueController } from './queue.controller';
 import { ScanController } from './scan.controller';
 import { SnapshotController } from './snapshot.controller';
 import { SecurityDataController } from './security-data.controller';
+import { DataFreshnessController } from './data-freshness.controller';
 import { injectLoggerModule } from '../../../libs/logging/src';
 
 @Module({
@@ -30,6 +31,7 @@ import { injectLoggerModule } from '../../../libs/logging/src';
     ScanController,
     SnapshotController,
     SecurityDataController,
+    DataFreshnessController,
   ],
 })
 export class AppModule {}

--- a/apps/cli/src/data-freshness.controller.spec.ts
+++ b/apps/cli/src/data-freshness.controller.spec.ts
@@ -30,6 +30,10 @@ describe('DataFreshnessController', () => {
     controller = module.get<DataFreshnessController>(DataFreshnessController);
   });
 
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });

--- a/apps/cli/src/data-freshness.controller.spec.ts
+++ b/apps/cli/src/data-freshness.controller.spec.ts
@@ -1,0 +1,72 @@
+import { MockProxy, mock } from 'jest-mock-extended';
+import { Test, TestingModule } from '@nestjs/testing';
+import { DataFreshnessController } from './data-freshness.controller';
+import { CoreResultService } from '@app/database/core-results/core-result.service';
+import { fetchCommitDate } from '@app/security-data/fetch-commit-date';
+
+jest.mock('@app/security-data/fetch-commit-date');
+
+describe('DataFreshnessController', () => {
+  let controller: DataFreshnessController;
+  let mockCoreResultService: MockProxy<CoreResultService>;
+  let mockedFetchCommitDate: jest.MockedFunction<typeof fetchCommitDate>;
+
+  beforeEach(async () => {
+    mockCoreResultService = mock<CoreResultService>();
+    mockedFetchCommitDate = fetchCommitDate as jest.MockedFunction<
+      typeof fetchCommitDate
+    >;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DataFreshnessController],
+      providers: [
+        {
+          provide: CoreResultService,
+          useValue: mockCoreResultService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<DataFreshnessController>(DataFreshnessController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('updateDataFreshnessDates', () => {
+    it('should fetch dates and update core results', async () => {
+      mockedFetchCommitDate
+        .mockResolvedValueOnce('2024-01-01') // DAP
+        .mockResolvedValueOnce('2024-01-02'); // HTTPS
+
+      await controller.updateDataFreshnessDates();
+
+      expect(mockedFetchCommitDate).toHaveBeenCalledTimes(2);
+      expect(mockedFetchCommitDate).toHaveBeenCalledWith(
+        'data/source-lists/dap_top_100000_domains_30_days.csv',
+        expect.anything(),
+      );
+      expect(mockedFetchCommitDate).toHaveBeenCalledWith(
+        'data/source-lists/cisa_https.csv',
+        expect.anything(),
+      );
+
+      expect(mockCoreResultService.updateDataFreshnessDates).toHaveBeenCalledWith(
+        '2024-01-01',
+        '2024-01-02',
+      );
+    });
+
+    it('should throw an error if fetchCommitDate fails', async () => {
+      mockedFetchCommitDate.mockRejectedValue(new Error('GitHub API Error'));
+
+      await expect(controller.updateDataFreshnessDates()).rejects.toThrow(
+        'GitHub API Error',
+      );
+      expect(
+        mockCoreResultService.updateDataFreshnessDates,
+      ).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/cli/src/data-freshness.controller.ts
+++ b/apps/cli/src/data-freshness.controller.ts
@@ -1,0 +1,34 @@
+import { Controller } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
+
+import { fetchCommitDate } from '@app/security-data/fetch-commit-date';
+import { CoreResultService } from '@app/database/core-results/core-result.service';
+
+const DAP_FILE_PATH =
+  'data/source-lists/dap_top_100000_domains_30_days.csv';
+const HTTPS_FILE_PATH = 'data/source-lists/cisa_https.csv';
+
+@Controller()
+export class DataFreshnessController {
+  private readonly logger = new Logger(DataFreshnessController.name);
+
+  constructor(private readonly coreResultService: CoreResultService) {}
+
+  async updateDataFreshnessDates(): Promise<void> {
+    this.logger.log('Fetching last-commit dates for DAP and HTTPS source files');
+
+    const [dapDataDate, httpsDataDate] = await Promise.all([
+      fetchCommitDate(DAP_FILE_PATH, this.logger),
+      fetchCommitDate(HTTPS_FILE_PATH, this.logger),
+    ]);
+
+    this.logger.log(
+      `Updating all core_result rows: dap_data_date=${dapDataDate}, https_data_date=${httpsDataDate}`,
+    );
+    await this.coreResultService.updateDataFreshnessDates(
+      dapDataDate,
+      httpsDataDate,
+    );
+    this.logger.log('Data freshness dates updated successfully');
+  }
+}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -9,6 +9,7 @@ import { QueueController } from './queue.controller';
 import { ScanController } from './scan.controller';
 import { SnapshotController } from './snapshot.controller';
 import { SecurityDataController } from './security-data.controller';
+import { DataFreshnessController } from './data-freshness.controller';
 
 import pino from 'pino';
 import { getRootLogger } from '../../../libs/logging/src';
@@ -181,6 +182,17 @@ async function securityData() {
   await nestApp.close();
 }
 
+async function dataFreshness() {
+  const nestApp = await bootstrap();
+  const logger = createCommandLogger('data-freshness');
+  const controller = nestApp.get(DataFreshnessController);
+  logger.info('updating data freshness dates for DAP and HTTPS source files');
+
+  await controller.updateDataFreshnessDates();
+  printMemoryUsage(logger);
+  await nestApp.close();
+}
+
 async function requeueStaleScans() {
   const nestApp = await bootstrap();
   const logger = createCommandLogger('requeue-stale-scans');
@@ -303,6 +315,14 @@ async function main() {
       'security-data fetches security data from a CSV and saves it to disk',
     )
     .action(securityData);
+
+  // data-freshness
+  program
+    .command('data-freshness')
+    .description(
+      'data-freshness fetches the last-commit dates for the DAP and HTTPS source files from GitHub and bulk-updates dap_data_date and https_data_date on all core_result rows',
+    )
+    .action(dataFreshness);
 
   // requeue stale scans
   program

--- a/entities/core-result.entity.ts
+++ b/entities/core-result.entity.ts
@@ -41,6 +41,16 @@ export class CoreResult {
   @Expose({ name: 'scan_date' })
   updated: string;
 
+  @Column({ type: 'date', nullable: true })
+  @Expose({ name: 'dap_data_date' })
+  @Exclude()
+  dapDataDate?: string;
+
+  @Column({ type: 'date', nullable: true })
+  @Expose({ name: 'https_data_date' })
+  @Exclude()
+  httpsDataDate?: string;
+
   @OneToOne(() => Website, (website) => website.coreResult, {
     onDelete: 'CASCADE',
   })
@@ -608,6 +618,8 @@ export class CoreResult {
     '404_test',
     'source_list',
     'scan_date',
+    'dap_data_date',
+    'https_data_date',
     'primary_scan_status',
     'accessibility_scan_status',
     'dns_scan_status',

--- a/libs/database/src/core-results/core-result.service.spec.ts
+++ b/libs/database/src/core-results/core-result.service.spec.ts
@@ -569,4 +569,27 @@ describe('CoreResultService', () => {
     );
     expect(mockRepository.insert).not.toHaveBeenCalled();
   });
+
+  describe('updateDataFreshnessDates', () => {
+    it('bulk-updates dapDataDate and httpsDataDate on all rows', async () => {
+      const mockExecute = jest.fn().mockResolvedValue({ affected: 42 });
+      const mockWhere = jest.fn().mockReturnValue({ execute: mockExecute });
+      const mockSet = jest.fn().mockReturnValue({ where: mockWhere });
+      const mockUpdate = jest.fn().mockReturnValue({ set: mockSet });
+      mockRepository.createQueryBuilder.mockReturnValue({
+        update: mockUpdate,
+      });
+
+      await service.updateDataFreshnessDates('2026-05-16', '2026-05-21');
+
+      expect(mockRepository.createQueryBuilder).toHaveBeenCalled();
+      expect(mockUpdate).toHaveBeenCalledWith(CoreResult);
+      expect(mockSet).toHaveBeenCalledWith({
+        dapDataDate: '2026-05-16',
+        httpsDataDate: '2026-05-21',
+      });
+      expect(mockWhere).toHaveBeenCalledWith('1 = 1');
+      expect(mockExecute).toHaveBeenCalled();
+    });
+  });
 });

--- a/libs/database/src/core-results/core-result.service.ts
+++ b/libs/database/src/core-results/core-result.service.ts
@@ -601,4 +601,24 @@ export class CoreResultService {
       await this.coreResultRepository.insert(coreResult);
     }
   }
+
+  /**
+   * Bulk-updates dapDataDate and httpsDataDate on every row in core_result.
+   *
+   * These two columns reflect the freshness of the external source files that
+   * supply DAP analytics and HTTPS/HSTS data. Because a single date applies
+   * to the entire dataset (not per-scan), one bulk UPDATE is correct and
+   * intentionally leaves scan_date (updated) untouched.
+   */
+  async updateDataFreshnessDates(
+    dapDataDate: string,
+    httpsDataDate: string,
+  ): Promise<void> {
+    await this.coreResultRepository
+      .createQueryBuilder()
+      .update(CoreResult)
+      .set({ dapDataDate, httpsDataDate })
+      .where('1 = 1')
+      .execute();
+  }
 }

--- a/libs/security-data/src/fetch-commit-date.spec.ts
+++ b/libs/security-data/src/fetch-commit-date.spec.ts
@@ -67,4 +67,26 @@ describe('fetchCommitDate', () => {
       fetchCommitDate('data/source-lists/cisa_https.csv', mockLogger),
     ).rejects.toThrow('no commits');
   });
+
+  it('throws when the GitHub API returns malformed JSON', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockRejectedValue(new SyntaxError('Unexpected token')),
+    });
+
+    await expect(
+      fetchCommitDate('data/source-lists/cisa_https.csv', mockLogger),
+    ).rejects.toThrow('malformed JSON');
+  });
+
+  it('throws when the latest commit is missing commit.committer.date', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue([{ commit: { committer: {} } }]),
+    });
+
+    await expect(
+      fetchCommitDate('data/source-lists/cisa_https.csv', mockLogger),
+    ).rejects.toThrow('commit.committer.date');
+  });
 });

--- a/libs/security-data/src/fetch-commit-date.spec.ts
+++ b/libs/security-data/src/fetch-commit-date.spec.ts
@@ -1,0 +1,70 @@
+import { Logger } from '@nestjs/common';
+import { fetchCommitDate } from './fetch-commit-date';
+
+const mockLogger = {
+  log: jest.fn(),
+  error: jest.fn(),
+} as unknown as Logger;
+
+describe('fetchCommitDate', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns a YYYY-MM-DD string from the most recent commit date', async () => {
+    const mockResponse = [
+      { commit: { committer: { date: '2026-05-16T18:30:00Z' } } },
+    ];
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockResponse),
+    });
+
+    const result = await fetchCommitDate(
+      'data/source-lists/dap_top_100000_domains_30_days.csv',
+      mockLogger,
+    );
+
+    expect(result).toBe('2026-05-16');
+  });
+
+  it('strips the time portion and keeps only YYYY-MM-DD', async () => {
+    const mockResponse = [
+      { commit: { committer: { date: '2026-01-01T00:00:00Z' } } },
+    ];
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockResponse),
+    });
+
+    const result = await fetchCommitDate(
+      'data/source-lists/cisa_https.csv',
+      mockLogger,
+    );
+
+    expect(result).toBe('2026-01-01');
+  });
+
+  it('throws when the GitHub API returns a non-OK response', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+    });
+
+    await expect(
+      fetchCommitDate('data/source-lists/cisa_https.csv', mockLogger),
+    ).rejects.toThrow('GitHub API request failed');
+  });
+
+  it('throws when the commits array is empty', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue([]),
+    });
+
+    await expect(
+      fetchCommitDate('data/source-lists/cisa_https.csv', mockLogger),
+    ).rejects.toThrow('no commits');
+  });
+});

--- a/libs/security-data/src/fetch-commit-date.ts
+++ b/libs/security-data/src/fetch-commit-date.ts
@@ -7,8 +7,8 @@ const GITHUB_COMMITS_API =
  * Fetches the date of the most recent commit that touched a given file path in
  * the GSA/federal-website-index repository, returning it as a YYYY-MM-DD string.
  *
- * Throws on non-200 responses or when the commits array is empty (the file path
- * is wrong or has never been committed).
+ * Throws on non-200 responses or when the response shape does not include a
+ * commit date for the requested file.
  */
 export async function fetchCommitDate(
   filePath: string,
@@ -30,18 +30,30 @@ export async function fetchCommitDate(
     );
   }
 
-  const commits: Array<{
-    commit: { committer: { date: string } };
-  }> = await response.json();
+  let commits: unknown;
+  try {
+    commits = await response.json();
+  } catch (error) {
+    const err = error as Error;
+    throw new Error(
+      `GitHub API returned malformed JSON for path "${filePath}": ${err.message}`,
+    );
+  }
 
-  if (!commits.length) {
+  if (!Array.isArray(commits) || !commits.length) {
     throw new Error(
       `GitHub API returned no commits for path "${filePath}" — check that the path is correct`,
     );
   }
 
   // The date field is ISO 8601 (e.g. "2026-05-21T18:00:00Z"); keep only YYYY-MM-DD.
-  const isoDate = commits[0].commit.committer.date;
+  const isoDate = commits[0]?.commit?.committer?.date;
+  if (typeof isoDate !== 'string' || !isoDate) {
+    throw new Error(
+      `GitHub API response did not include commit.committer.date for path "${filePath}"`,
+    );
+  }
+
   const dateOnly = isoDate.split('T')[0];
   logger.log(`Last commit date for ${filePath}: ${dateOnly}`);
   return dateOnly;

--- a/libs/security-data/src/fetch-commit-date.ts
+++ b/libs/security-data/src/fetch-commit-date.ts
@@ -1,0 +1,48 @@
+import { Logger } from '@nestjs/common';
+
+const GITHUB_COMMITS_API =
+  'https://api.github.com/repos/GSA/federal-website-index/commits';
+
+/**
+ * Fetches the date of the most recent commit that touched a given file path in
+ * the GSA/federal-website-index repository, returning it as a YYYY-MM-DD string.
+ *
+ * Throws on non-200 responses or when the commits array is empty (the file path
+ * is wrong or has never been committed).
+ */
+export async function fetchCommitDate(
+  filePath: string,
+  logger: Logger,
+): Promise<string> {
+  const url = `${GITHUB_COMMITS_API}?path=${encodeURIComponent(filePath)}&per_page=1`;
+  logger.log(`Fetching last commit date for ${filePath} from ${url}`);
+
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API request failed for path "${filePath}": ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const commits: Array<{
+    commit: { committer: { date: string } };
+  }> = await response.json();
+
+  if (!commits.length) {
+    throw new Error(
+      `GitHub API returned no commits for path "${filePath}" — check that the path is correct`,
+    );
+  }
+
+  // The date field is ISO 8601 (e.g. "2026-05-21T18:00:00Z"); keep only YYYY-MM-DD.
+  const isoDate = commits[0].commit.committer.date;
+  const dateOnly = isoDate.split('T')[0];
+  logger.log(`Last commit date for ${filePath}: ${dateOnly}`);
+  return dateOnly;
+}


### PR DESCRIPTION
## Description

This PR implements data freshness tracking by recording the last-commit dates of the source files used for DAP and HTTPS data in the scan results.

References: https://github.com/GSA/site-scanning/issues/1885

## Changes

- **New CLI Command**: Added `updateDataFreshnessDates` command to fetch last-commit dates from the Federal Website Index repository for:
  - `data/source-lists/dap_top_100000_domains_30_days.csv` (DAP data)
  - `data/source-lists/cisa_https.csv` (HTTPS data)
  
- **New Database Columns**: Added two new nullable date columns to `core_result` table:
  - `dap_data_date`: Tracks when DAP source data was last updated
  - `https_data_date`: Tracks when HTTPS source data was last updated

- **API Exposure**: Added new fields to the `WebsiteApiResultDTO` to expose data freshness dates via the REST API

- **GitHub Actions Workflow**: Created `update-data-freshness-dates.yml` to automatically run the data freshness update command on a scheduled basis

- **Service Implementation**:
  - `fetchCommitDate`: New service in `libs/security-data` that queries the GitHub API to find the last commit date for a specific file path
  - `CoreResultService.updateDataFreshnessDates`: Updates all rows in the database with the latest freshness dates
  
- **Tests**: Added comprehensive test coverage for the new controller and services

## Why

This enables transparency about how fresh the DAP and HTTPS scan data is across the entire dataset. Consumers of scan results can now see exactly when the source data was last updated, which is critical for understanding data quality and recency.

## Testing

- Unit tests added for data freshness controller and fetch-commit-date service
- Tests verify that the GitHub API integration correctly retrieves commit dates
- Service tests confirm database updates work correctly
